### PR TITLE
mark chapter titles in v1p1

### DIFF
--- a/kANe/v1p1.md
+++ b/kANe/v1p1.md
@@ -50,7 +50,9 @@ Hon. Secretary, Bhandarkar Oriental
 
 Resourol Institute, Poona 4 
 
-## 00 Preface
+## 00 
+
+### Preface
 
 PREFACE 
 
@@ -82,7 +84,7 @@ FOUNDED
 
 TIT 
 
-## 00 List of Abbreviations
+### List of Abbreviations
 
 LIST OF ABBREVIATIONS 
 
@@ -372,7 +374,7 @@ Recently (1959) Dr. Ram Gopal has brought out a large work on 'India of Vedic Ka
 
 History of Dharmaśāstra 
 
-## 03 Date of Dharmasastra works
+## 03 Date of Dharmaśāstra works
 
 3. When Dharmasastra works were first composed 
 
@@ -540,7 +542,7 @@ The gļhyasūtras belonging to the Sāmaveda are :
 
 The Atharvaveda has the Kausika-sūtra as its Grhya. which was edited by Prof. Bloomfield. Vide Prof. Belvalkar Presentation Vol. pp. 28-33 for a paper by Mr. O. G. Kashikar for corrections in it and a paper Kausikasūtra and the Atharva veda' by Prof. Edgerton in F. W. Thomas Presentation Vol. pp. 78-81. There are several commentaries on it. It devotes a large part of it to utpūtas and sūntis. 
 
-## 04 The Dharmasutras
+## 04 The Dharmasūtras
 
 4. The Dharmasutras It seems that originally many, though not all, of the dharma. siiras formed part of the Kalpasūtras and were studied in distinct sūtrucaranas. Some of the extant dharmasūtras here and there show in unmistakable terms that they presuppose the Gshyasūtra of the caraņa to which they belong. Compare Āp. Dh. S. I, 1. 4. 16 with Ap. Gș. S. I. 12 and II. 5; and Baud. Dh. S. II. 8. 20 with Baud. Gr. S. II. 11. 42 (and other sūtras ).54 The Dharmasūtras belonging to all sūtracaraṇas have not come down 
 
@@ -586,7 +588,7 @@ History of Dharmaśāstra
 
 are given in the H. of Dh. Vol. II where they are explained ; āghārau (p. 1051 n. 2360), Ajyabhāga (p. 1059 n. 2371), Abhi ghārana (p. 528 n), Avadāna (528, 1061 n), Upastarana (p. 1061 n), Pavitra ( 211 n., 1021 n), Paryagnikarana (p. 1120 n), (Pranītā p. 1022-23), Pratyabhighārana (p. 1053 n). The Āp. Dh. S. (I. 4. 12. 10 ) makes the interesting statement "religious rites were declared in the Brāhmaṇas, the texts of those rites have been lost, (but those texts ) can be inferred from the actual per formance (of the rites that are in vogue): "brāhmanoktā vidhayas teşām utsannāḥ pathāḥ prayogād-anumiyanto'. This shows that an early writer like Apastamba (who flourished some centuries before the Christian era ) was aware that Brāhmaṇa works had once described many of the gļhya rites, but that in his day such Brāhmaṇa texts had been lost. 
 
-## 05 The Dharmasutra of Gautama
+## 05 The Dharmasūtra of Gautama
 
 5. The Dharmasutra of Gautama. This has been printed several times (there is Dr. Stenzler's edition of 1876, the Calcutta edition of 1876, the Ānanadāśrama edition with the commentary of Haradatta, and the Mysore Government edition with the bhāsya of Maskarin ; it was trans lated by Bühler in S. B. E., Vol. II. with an introduction). The Anandāśrama edition of 1910 which is incorrect in a few places (e. g. 21.7 ) has been used in this work. This dharmasūtra is, as we shall see, the oldest of those we have. The Gautama dharmasūtra was specially studied by followers of the Sāmaveda ( see note 55 above). The commentary on the Caranavyuha tells us that Gautama was one of the nine sub-divisions of the Rānāvanīya school of the Sāmaveda. A teacher Gautama is mentioned frequently in the Lātyāyanaśrautasūtra (. g. I. 3.3 and I. 4. 17 ) and in the Drähyāyanaśrauta (e. g. I. 4. 17, IX. 3. 15 ) of the Sāmaveda. The Gobhilagphya (III. 10.6) which belongs to the Sāmaveda cites Gautama as an authority. There fore it is not improbable that a complete Gautamasutra embody ing Srauta, Grhya and Dharma doctrines once existed. There are other indications pointing to the close connection of the Gautamadharmasūtra with the Sāmaveda. Chapter 26 of the dharmasūtra about Krcchra penance is the same, almost word for word, as the Sāmavidhānas9 Brāhmaṇa (I. 2, Burnell's ed.). 59 There are, however, considerable divergences; e. g. tit. 17. 9. 26. 10-12 
 
@@ -908,7 +910,7 @@ such usages of countries, castes and families are valid and authoritative as are
 
 The Mitāksarā, the Smộticandrikā, Hemādri, Madhava and (ther writers quote a sloka-Gautama. Vide Parāśara-Madhaviya, vol. I, part I, p.7. Aparārka, Hemādri and Mādhava quote VỊddha-Gautama, while the Dattakamimāṁsā (p. 72 ) quotes Vrddha-Gaut. and Brhad-Gaut. side by side on the same point. These are later works. Jīvānanda publishes a smrti of Vrddha Gautama in 22 chapters and about 1700 verses (part II, pp. 497 636 ), where it is said that Yudhisthira asked Krsna about the charias of the four castes. This smrti seems to have been originally taken from the Āývamedhikaparva of the Mahābhārata, as Mādhava and others cite verses occurring in it as from that parya ( vide Parāśaramadhaviya vol. I, part I, pp. 108-110 ). 
 
-## 06 The Baudhāyana Dharmasutra
+## 06 The Baudhāyana Dharmasūtra
 
 6. The Baudhāyana Dharmasutra This has been edited several times (text by Dr. Hultzsch at Leipzig in 1884, text in the Anandāśrama collection of smrtis and in the Mysore Government Oriental Series in 1907 with the commentary of Govindasvāmin; translated in S. B. E., Vol. 14, with an Introduction). The Mysore edition has been used in this work. Baudhāyana is a teacher of the Krsnayajurveda. A complete set of the Baudhāyanasñtras has not yet been recovered and has not been as carefully preserved as the sūtras of Apa stamba and Hiranyakesin. Dr. Burnell arranges Baudhāyana's sütras into six sūtras, the Srautasütra in 19 praśnas (probably ); Karnāntasūtra in 20 adhyāyas ; Dvaidhasūtra in four prašnas ; Grhyasūtra in four praśnas ; Dharmasútra in four praśnas ; Sulvasūtra in three adhyāyas. The commentators offer no indi cation as to the place originally assigned to the grhya, dhurma and sulva sutras in the whole collection. Dr. Caland in his mono graph ( A. D. 1903 ) 'Uber das Rituelle sūtra des Bandhayana' gives on p. 12 the contents of the Baudhāyanasūtra as follow: Praśnas I-XXI Śrauta, XXII-XXV Dvaidha, XXVI XVIII 
 
@@ -1124,7 +1126,7 @@ In the tarpana, Baud. (II. 5. 21 ) mentions several appellations of Ganesa, viz.
 
 According to Burnell the oldest commentator on the Baudhāyanaśrauta-sūtra was Bhavasvāmin, whom he placed in the 8th century. The commentary of Govindasvamin on the Dharmasūtra is a learned one and is generally to the point. He appears to be a very late writer. 
 
-## 07 Dharmasutra of Āpastamba
+## 07 Dharmasūtra of Āpastamba
 
 7. Dharmasutra of Āpastamba. This has been edited several times (viz. by Bühler in the Boinbay Sanskrit Series with large extracts from Haradatta's commentary called Ujjvalā and also at Kumbhakonam with the complete commentary of Haradatta and translated by Bühler with an introduction in S. B. E. vol. II). The Apastan bakalpasūtra of the Taittiriya Sākhā of the black Yajurveda is divided into 30 pruśnas. According to Bühler, the first 24 praśnas contain the treatment of Srauta sacrifices; the 25th contains paribhūṣās, pravarakhanda, and Hautraka prayers to be recited by Hotr priests ; 26th and 27th praśnas constitute the Gșhyasūtra, the 28th and 29th Dharmasūtra and the 30th praśna is Sulvasútra. Bühler seems to be slightly inaccurate here. According to Caundappa, who commented on the Āpastambiya sūtras in the 14th century, the Āpastambiyaman trapātha forms the 25th and 26th praśnas of the Kalpasūtra and the Gșhyasūtra forms 27th prasna.80 The Srauta-sūtra of 80 पंचविशेष षइविंशे गृहमन्त्राः प्रपञ्चिताः । प्रश्नेथ सप्तर्विशे स्याब्रह्मतन्त्रविधिक्रमाती 
 
@@ -1722,7 +1724,7 @@ Shri. A. N. Krishna Aiyangar in Kunhan Raja Felicitation Volume (pp. 392–397 )
 
 27 
 
-## 08 Hiranyakeši-Dharmasūtra
+## 08 Hiraṇyakeśi-Dharmasūtra
 
 8. Hiranyakeši-Dharmasūtra 
 
@@ -1780,7 +1782,7 @@ History of Dharmaśāstra
 
 in the Hiraṇyakeši school; e. g. he comments on 'padūnam', ou *adhasanašāyi' for ardhāsanašāyi (the reading of the sūtra ), on 'ātmasvastyayanārthena' (Ap. II. 5. 11. 9 ) for svastyaya lārthena' of the ms. of Hir. The explanations of the two writers sometimes differ, as for example on ācāryādhinas syād anyatra pataniyebhyah' (Ap. I. 1. 2. 19104). One more circum stance that is worthy of note is that the Ujjvalā of Haradatta does not contain many quotations from Smộtis as compared with his commentary on the Gautamadharmasūtra. Although ono may be inclined to hold that it is Mahādova who borrows, it inust be clearly recognized that there is hardly any positivo evidence in support of such a view. There is a commentary called Vaijayanti on the Hiranyakesi-srauta-sūtra. This Malādeva is very likely identical with the Mahadeva who commented upon the dharmagūtra. 
 
-## 09 Vasistha-dharmasutra
+## 09 Vasiṣṭha-dharmasūtra
 
 9. Vasistha-dharmasutra. This dlurmusutra has been printed several times. The collec tion of Jivanada (part II, pp. 456-496 ) contains only 20 chapters and a portion of the 21st and so does the collection of Mr. M. N. Dutt (Calcutta 1908). The Anandāśrama collection of sinītis ( 1905, pp. 187-231 ) and the edition of Dr. Führer in the B. S. series (1916) contain thirty chapters. According to Dr. Jolly (R. u 8, p. 6 ) some mss. give only six or ten chapters, The Vasisthadharmasütra with the commentary called Vidvan modini was printed at Benares. In the following Dr. Führer's 
 
@@ -2072,7 +2074,7 @@ prose passage. The Kalpataru profusely quotes Vasistha in Gșhasthakāņda ( 41 
 
 That Yajñasvāmin wrote a commentary on the Vas. Dh. S. follows from Govindasvāmin's comment on Baud. Dh. S. (II. 2.51), where he quotes Vas, 21. 13 and Yajñasyāmin's comment thereon. 
 
-## 10 Visnudharmasutra
+## 10 Viṣṇudharmasūtra
 
 10. Visnudharmasutra. The Vişnudharmasūtra has been printed several times in India, viz. by Jivananda in his Dharmasastrasangraha (1876 part I pp. 70-176 ) by the Bengal Asiatic Society (1881, ed. by Dr. Jolly with extracts from the commentary Vaijayanti ), by M. N. Dutt (Dharmaśāstra texts, vol. II pp. 541-666, Calcutta, 1909) and translated by Dr. Jolly (in the S. B. E. vol. VII with an Introduction). In the present work Dr. Jolly's edition has been used. The gūtra contāins one hundred chapters. Though the number of chapters is so large, the sūtra is not very extensive. There are several chapters such as 40, 42 and 76 that contain only one sūtra and one verse. The first chapter and the last two are entirely in verse; the remaining chapters are in mixed prose and verse, the versified portion being generally at the end of each chapter. As pointed out by the Vaijayanti the sūtra is in close relation to one of the oldest schools of the Yajurveda, viz. Katha. It also stands in a peculiar relation to the extant Manusmộti. According to the Caranavyūha, Kathmand 
 
@@ -2310,7 +2312,7 @@ From the fact that the Sarasvativilisa quotes several times the sutras of Visnu 
 
 So far only the printer and well-known Jharmasūtras have been passed under review. But there were numerous other dharmasūtras which are either noir extant in rare m88. or are not yet discovered but are only to be reconstructed from quotations. It is now time to discuss them. 
 
-## 11 The Dharmasutra of Harita
+## 11 The Dharmasūtra of Hārīta
 
 11. The Dharmasutra of Harita That Hārīta was an ancient sūtrakāra on dharma is quite patent from the fact that the dhurmasitras of Baudhå. yana, Apastamba and Vasiştha quote him as an authority. 
 
@@ -2502,7 +2504,7 @@ Dr. S. C. Banerjee in J. O. I. ( Baroda ) vol. VIII pp. 14-37 ( 1958 ) published
 
 If all passages of Hārīta quoted in the several nibandhas were collected and carefully studied it would be found that several verses are common to it and Manu and other smộti kāras. For example, Kalpataru (op Grhastha ) p. 43, noted that the verse Vrsalīphenapītasya' is common to Manu, Yama and Hūrīta (it is Manu IV. 19). The same kända on p. 310 quotes with the word ('evam hyāha') three verses one of which ( pañca paśvanyte hanti) is the same as Manu VIII. 98. 
 
-## 12 The Dharmasutra of Sankha-Likhita
+## 12 The Dharmasūtra of Saṅkha-Likhita
 
 12. The Dharmasutra of Sankha-Likhita From the Tantravārtika we learn (note 55 above ) that the Dharmasūtra of Sankha-Likhita was specially studied by the Vājasaneyins ( the followers of the white Yajurveda ). The Tantravārtika also quotes a few words from thnt Dhar. masūtra which constitute an Anustubh pada.138 The Mahá bhārata ( in Säntiparvan, chap. 23. 18-43 ) narrates the story of the two brothers, Sankha and Likhita, who resided in sepa rate dwellings surrounded by trees. Once Likhita came to the ábrama ( hermitage ) of Sankha in his absence. He took some ripe fruits from some of the trees of Sarkba's aśrama and ate them. While he was eating, Saikha came and asked him where he got the fruits. Likhita smiled and told his brother that he took them from his trees. Then Sarkha got angry and told his brother that he was guilty of theft and asked 
 
@@ -2630,7 +2632,7 @@ HET II. 141. 143 ' Tefat 77 gala za trant van' quoted in PCT. HISZEN
 
 p. 98. Compare \#9 8. 44 
 
-## 13 Mānavadharmasutra
+## 13 Mānavadharmasūtra
 
 13. Mānavadharmasutra-Did it exist? 
 
@@ -2718,7 +2720,7 @@ early. Kumărila, who was a most learned and profound stu dent of the various br
 
 The foregoing discussion will, it is hoped, induce every impartial critic to endorse the conclusion that, on the materials so far available, the theory that the Mānavadharmasūtra once existed and that the extant Manusmrti is a recast of that Būtra must be held not proved. 
 
-## 14 The Arthasastra of Kautilya 
+## 14 The Arthaśāstra of Kauṭilya
 
 14. The Arthasastra of Kautilya 
 
@@ -4574,7 +4576,7 @@ Asvastana'i. e. storing only as much corn as would suffice for a day or he may f
 
 FOUNDED 7 
 
-## 15 Vaikhānasa-dharma-prasna
+## 15 Vaikhānasa-dharma-praśna
 
 15. Vaikhānasa-dharn-prasna 
 
@@ -4708,7 +4710,7 @@ Aparārka quotes about a hundred verses of Atri on vari ous topics. Aparırka qu
 
 Mr. A. N. Krishna, Aiyungar edits an Ātreya-smrti in Adyar Library Bulletin, vol. VI, part 4. 
 
-## 17 Usanas
+## 17 Uśanas
 
 17. Usanas Kāvya Uśanas is an ancient sage in the Rgveda ; vide æg. I. 83. 5, where Kavya Uśanas is said to have been an helper of Indra and brought out the cows (carried away and concealed by the Panis). In Rg. VIII. 23. 17 that sage is said to have established Agni for Manu and in Rg IX. 87. 3 Ušanas is called a řsi and vipra and one who knew the hidden place where cows were concealed. 
 
@@ -4902,7 +4904,7 @@ SITO
 
 11 FOUNDED 
 
-## 18 Karva and Känva 
+## 18 Kaṇva and Kāṇva 
 
 18. Karva and Känva 
 
@@ -4930,7 +4932,7 @@ VO
 
 History of Dharmasastra kämya, vrddhisrāddha and pārvana ), XI. 18 (verse viz. pūrvajanmakrtam karma daivamityabhidhiyate ), XV. 17 (verse), XVII. I ( verse on Stridhana ), XV. 3 (three verses on prayascitta). 
 
-## 19 Kasyapa and Kasyapa
+## 19 Kaśyapa and Kāśyapa
 
 19. Kasyapa and Kasyapa Baudhayana ( Dh. S. I. 11. 20) cites a verse which con tains the view of Kaśyapa that a woman who is bought can. not be a patnī and that she is not authorised to take part in religious ( daiva ) rites or rites for the Manes.254 This verse is ascribed to Katyayana in the Smrticandrika ( I. p. 87 ). The Vanaparva quotes gāthcs of Kāśyapa on forbearance ( 29. 35-40). Whether Kaśyapa and Kāśyapa are two different writers of dharmasútras it is rather difficult to say. Probably they are identical. It appears that the dharmasútra of Kāśyapa comprised all the usual topics of dharmasūtras, such as daily duties, sraddha, asauca, prayascitta. This sutra has been quoted by all eminent writers from Visvarūpa down wards. Visvarāpa quotes Kasyapa (in prose ) on the priya scitta for contact with candila 8866 and for killing a cow when the sinner is a brāhmana or a member of another caste. 288 The Mit. (on Yaj. III. 23) quotes a prose passage from Kāsyapa on freedom from impurity on death of infants.257 The quotations in the Smộticandrikā on ähnika and traddha are all in verse. Haradatta on Gautama (22. 18 ) quotes a sūtra on the prāyaścitta for govadhu, 258 which is also quoted by Visvarūpa. Haradatta (on Gaut. 23. 26 ) quotes a very long sūtra on the prāyascittu for eating several things and doing 
 
@@ -5018,7 +5020,7 @@ History of Dharmaśāstra
 
 Rg. Mantras and on pp. 1103, 1190, 1199 provides expiation (in prose) for causing the death of a cow, for one who touches or carries to tbe cemetery or cremates a suicide, and for close contact of Cāudālas with houses, earthenots and states that for children, the ayed and women the expiation is only half of what is prescribed for grown-up inen. Apurárka quotes only one verse on Yáj. III. 264-265 as mild expiation in cer tain cases of causing the death of a cow. The Mit. on Yāj. III. 30 cites a long prose passage as regards the times when a bath with clothes on is necessary. 
 
-## 22 Jatukarnya
+## 22 Jātūkarṇya
 
 22. Jatukarnya 
 
@@ -5148,7 +5150,7 @@ The Mahābhārata ascribes the view to Devala tbat in man there are three jyoti8
 
 Aparārka and the Smộticandrikā cite verses from Devala on partition, inheritance, on woman's power over stridhana. These show that Devala, the jurist, flourished about the same time as the great jurists Bșhaspati and Kätyāyana. 
 
-## 24 Paithinasi
+## 24 Paiṭhīnasi
 
 24. Paithinasi Though not enumerated in Yājsavalkya, Paithinasi seems to have been a comparatively ancient sūtrakāra on Dharma. On Yāj. III. 262 Viśvarūpa quotes a sutra of Paithinasi on the prāyaścitta for kiling a cow. Dr. Jolly (R. und $. p. 12 ) following Dr. Caland ("Ahnencult &c.' pp. 99, 109) thinks that Paithinasi belenys to the Atharvaveda as the prose quotations on frăddha agree with the ritual of the Atharvans. The Mit. (on Yāj. I. 53 ) quotes a sutra of Paithinasi to the effect that di person should marry a girl who is beyond the third degree on the mother's side and beyond the fifth on the father's side. 271 On Yāj. III. 17 the Mit. quotes two sūtras relating to impurity on death.272 The Smộticandrikā, A parárka, Hara datta and other writers quote numerous sūtras of Paithinasi. The Smyticandrika has a prose quotation on the duties of women.273 In another place the Smộticandriká (II. p. 263 ) cites a sūtra on partition.274 Aparūrka (p. 112 ) quotes two verses of Paithinasi recommending the practice of sati to women of all castes except Brühmana women. Aparärka (p. 239 ) quotes a sūtra saying that the food of astrologers; 
 
@@ -5208,7 +5210,7 @@ earliest writers and works to mention him. In the Deccani College Collection the
 
 The work does not produce the impression of being early. It is in the nature of a summary of larger works on dharma. All quotatious in Hemūdri cited from Budha are not found in the mss. 
 
-## 26 Brhaspati 
+## 26 Bṛhaspati 
 
 26. Brhaspati 
 
@@ -5274,7 +5276,7 @@ There is a Srauta sūtra and a Grhya sūtra attributed to Bhāradvāja. The Ms. 
 
 su110 
 
-## 27 Bharadvāja and Bharadvaja 
+## 27 Bharadvāja and Bhāradvāja 
 
 29. Bharadvāja and Bharadvaja 
 
@@ -5338,7 +5340,7 @@ f
 
 only for ten days, but could be annulled till the 9th year, if unfair. 393 It appears that the verses of Bharadvaja on vyavahāra are taken from a work other than the ancient work on politics. 
 
-## 28 Satatapa
+## 28 Śātātapa
 
 28. Satatapa Sãtātapa is enumerated among the expounders of dharma by Yāj. (I. 4-5) and by Parasura. Višvarūpa, Haradatta and Aparárka quote several proge passages of Sātātapa on prāyascitta. Visvarūpa (on Yāj. III. 236 ) tells us that Sātātapa -spoke of only eight, upapatakas and that without dealing with śrāddha as a principal topic he spoke of some of the subsidiary details of srāddha.294 The latter passage quoted from Sätātápa is a half verse. So Visvarūpa had a prose work of Sātītapa before him, mixed with verses, Haradatta on Gaut. ( Dh. S. 22. 18 ) quotes a prose passage of Sātāta pa about the penance for killing a cow. Visvarūpa on Yaj. III. 236 (part II. p. 93 ) states that Sătata pa mentioned in a prose passage only eight. Upapatakas .Sātātape tu. astum. vevopapātakāpyuktāni, athopa pătakānyagnyutsūdītyädini' eko. Visvarūpa on Yaj. III. 262 (part.2, p. 148) mentions a gutre of Sātätapa on präyuścittu. Maskarī on Gaut. 23. 35 quotes a prose passage from S. on prăyaścıttas unudaka-mutrapu. risayrabane svakakasparśane Sacelasuinam mahá vyåbrti. homuśca rajasvulnyamane cartildevann'. The Layhu-Satūta pa smrti (Anan. collection) contains several verses of Manu (e.g. verses 103, 105, 107 of it are respectively the girme as Mapu Ill, 237, III. 174, III. 233 and verses 45 and 58 refer to Sātätapa. Vfudba-Sätutupa is quoted several times in Kalpana taru e. g. ou pp. 98-99 of Brahma', on pp. 286, 405 of Grbus tha, 6 times on Sraddha. It is interesting to note that a verse of Satata pa quoted by the Mit. on Yáj. 1. 192 provides that a prāyasetta is not prescribed for men who bathe iri exidvink tbe water from a well or a dam dug or constructed by antyajus. The Mit. on Yáj. quotes several prose passages of 
 
@@ -5452,7 +5454,7 @@ FOUNDED
 
 1917 
 
-## 30 The Smrtis
+## 30 The Smṛtis
 
 30. The Smrtis 
 
@@ -5606,7 +5608,7 @@ History of Dharmaśāstra
 
 All these smộtis are not equal in authority. Most of them are obscure and are only rarely cited by ancient commenta tors. Exclusive of the dharmasutras hardly a dozen emptis have found commentators. If we are to judge of the authority of a smrti by the commentaries thereon, then the Manusmrti stands pre-eminent. Next to it is the Yājsavalkyasmrti. 
 
-## 31 The Manusmrti
+## 31 The Manusmṛti
 
 31. The Manusmrti So many editions of this work have been published in India since 1813 ( when the Manusmrti was first published at Calcutta ), that it is not possible to name them. In this work the Nirnayasāgara edition with the commentary of Kulluka has been used throughout. Another edition of Manu well known on this side of India is that of the late V. N. Mandlik, who published several commentaries such as those of Medha tithi, Govindaraja and others. The Manusmrti has been tran slated into English several times. The best known transla tion is that of Dr. Bühler in the S. B. E. series (vol. 25). Dr. Bühler also added an exhuustive and very scholarly intro duction to his translation and dealt with numerous problems connected with the Manusmrti. 
 
@@ -7726,7 +7728,7 @@ the four verses quoted from the Rāmāyana in the Dānasāgara could be traced i
 
 It is impossible to deal with the numerous writings on the Rāmāyana. Jacobi's German work on the Rāmāyana has been translated into English by Dr. S. N. Ghoshal and published by driblets in several volumes of the Journal of Oriental Institute ( Baroda ). Numerous dates have been proposed for the Rāmāyana e. g. the Department of Letters, Vol. 19 ( Calcutta University ) puts down 433 A. D. as its date. The Rāma story occurs frequently in the Mahābhārata e. g. vide Sabhāparva 50. 39, Vanaparva chap. 148-152 (31 verses ), chap. 274-293 ( verses about 769 ); several Purāṇas such as Brahmao, chap. 123 and 154, Padmapurāna ( several times in Pătălakhanda and Uttarakhanda ), Nārada purāna, Bhāgavatapurāna (IX. 10-11 about 82 verses ), Agni purāna (chap. 5-12, verses 189 ). One writer in Preraņā ' monthly for October 1949 says that there are fourteen commentaries on the Rāmāyana. 
 
-## 33 The Puranas
+## 33 The Purāṇas
 
 33. The Puranas The Yājňavalkyasmști provides that Purāna, NMAYA (Tarkaśāstra ), Mimāṁsā, Dharmaśāstra, the ( six, subsidiary lores of the Veda (angas ) and the Vedas (four )-these fourteen 
 
@@ -8120,7 +8122,7 @@ Umāsaṁhitā 51): Varāha
 
 is described ). (upavāşa ); Brahmavai varta ( 4th khanda, pūr- | Yugadharinas- vide also vārdha 8 and 26 ); Garuda under Kulisvarūpa. 116-137, Lirga, pūrvārdha Garuda 223 ; Linga 39 ; 83-84 ; Nirada, pirvār- Matsya 141-143, 164 ; dha 17-22, 110-124 ; Närada, pūrvārdha 41; Matsya 54-80, 94-100; Skanda VI. 272 ; Vāyu I. Padma ( bhūmi 87, brah- 32 and 58. 
 
-## 34 The Yājnavalkyasmrti
+## 34 The Yājñavalkyasmṛti
 
 34. The Yājnavalkyasmrti This smrti has been published dozens of times. In the following the Nirnayasāgara edition edited by Sāstri Moghe ( 1892 A. D. ) has been used and the Trivandrum edition when speaking of Viśvarūpa. 
 
@@ -8784,7 +8786,7 @@ he commits. Eighteen whole verses out of 29 quoted on p. 9 are not found but mos
 
 Mr. Divanji's mentality is rather peculiar. On p. 113 of JBBRAS vol. 29, Mr. Divunji gives a list of eight items on quotations from and references to this work (i. e. to Yogayājñavalkya that be edits ) in other works. The first item (Sänkara-bhüşya on Sv. Up.) has been dealt with already. The third reference is to Sarvadarśanasangraha of Madhavă. cārya ( a work of the 14th century A. D.). That work, he says, contains four quotations of the work he edits. That work also quotes Brhad- Yoga - Yājñavalkya on p. 143 *Hirunyagarbho Yogasya &c. ( which is Br. Y. Y. XII.5). The 8th item ( and the last) on that page is above all, the author of the Yajnavalkya-Sinrti has in III. 110 referred to a 'Yoga sāstra promulgated by me,' which can be none other than this (and refers to his own Introduction on p. 8). This is an extraordinary argument. He was a high judicial officer in the days of the British rule. He has written profusely on this one work but with great regret the present author has to say he has not kept an open and judicial mind. He assum es as indisputable what has to be proved to the satisfaction of the scholarly world. The uther items that he puts forward on p. 113 above cited are worth little. 
 
-## 35 The Parāsara Smrti 
+## 35 The Parāśara Smṛti 
 
 35. The Parāsara Smrti 
 
@@ -8962,7 +8964,7 @@ FOUNDED
 
 1917 
 
-## 36 The Nāradasmrti
+## 36 The Nāradasmṛti
 
 36. The Nāradasmrti 
 
@@ -9350,11 +9352,11 @@ SOUNDED
 
 1927 
 
+## 37 Bṛhaspati
+
 484 
 
 History of Dharmaśāstra 
-
-## 37 Brhaspati
 
 37. Brhaspati Brbaspati as a sūtra writer on politics has been dealt with above ( section 26 ). In this section Brhaspati the jurist will be spoken of. The complete smrti of Bșhaspati on law has not yet been discovered. It will be, when discovered, a very precious monument of ancient India, exhibiting the high water mark of Indian acumen in strictly legal principles and definitions. Dr. Fübrer collected together 84 verses ascribed to Brhaspati in the legal treatises of Aparārka and others with German translation and notes ( Leipzig, 1879 ) and Dr. Jolly collected about 711 verses of Brhaspati on law and translated them in the Sacred Books of the East (vol. 33 ). 
 
@@ -9668,7 +9670,7 @@ Brhaspati and Kityayana ( and sometimes to three viz. Nar., Br., Kat., or Manu, 
 
 पक्षविदो विदुः ॥ विश्वरूप cites without name on Yaj. II. 6 ; व्यव. मा. p. 291, कल्पतरु (व्यवहार p. 8t ascribes to बृह. and कात्या.. अपराके p. 810, स्मृतिच. (व्य. p. 40) and परा. मा. III. p. 81 ascribe to बृहस्पति. (2) तपग्विनां तु कार्याणि विथैरेव कारयेत् । मायायोगविदां चैव न स्वयं कोपकारणात् ॥ व्य. मा. p. 281 ascribes to both बृहस्पति and कात्या०. and वीर p. 30 to बृह० ; व्यव. नि. p. 12 to बृह. It occurs in कौटिलीय I. 19. 32. (3) लेख्यदोषास्तु ये केचित्सा क्षणां चैव ये स्मृताः । वादकाले तु वक्तव्याः पश्चादुक्तान द्वषयेत् ॥ स्मृतिच. ( व्य. p. 83 ) ascribes to कात्या. ; अपरार्क p. 872, वीर. p. 184, व्य. म. p. 39 ( to बृह० ). (4) अर्थिना संनियुक्तो वा प्रत्यर्थिप्रहितोपि वा । यो यस्यार्थे विवदने तयोर्जय पराजयौ ॥ अपरार्क p. 639 ascribes to कात्या., व्य. मा. p. 287 to नारद and कात्या. (6) अनुपस्थापयन्मूलं क्रयं वाप्यशोधयन् । यथाभियोगं धनिने धनं दाप्यो दम च सः । मिता. on या. II. ( 170 ascribes to Manu ) ; स्मृतिच. ( व्यव. ) p. 216, वि. र. p. 108, व्य. म. p. 197, वीर• p. 381 ascribes to कात्या, (8) योगाधमनविक्रीतं योगदानप्रतिग्रहम् । यस्य वाप्युपधिं पश्येत्तत्सर्व विनि वर्तयेत् ।। अपरार्क p. 783 ascribes to कात्या ; स. वि. (सरस्वतीविलास p. 287 to नारद. This is मनु 8. 165. (7) आहूय साक्षिणः पृच्छेनियम्य शपथैभृशम् । समस्तान्विदिताचारान्विज्ञा तार्थान्पृथक् पृथक् ।। मिता. on या. II. 73 ascribes to कात्या० ; अपरार्क ascribes to नारद. (8) साहसस्तेयपारुष्यगोभिशापे तथा च ये। भूमौ च पादपे क्षिप्रमकालेपि बृहस्पतिः ॥ कल्पतरु (व्यव. p. 67) ascribes to both कात्या. and बृह., and परा. मा. III p. 17t ascribes to बृह. (9) सानिध्येपि पितुः पुत्रैऋणं देय विभावितम् । जात्यन्धपनितोन्मत्त क्षयश्वित्रा. दिरोगिणः ॥ कात्या. act. to अपरार्क. p. 650 वि. र. p. 51, वि. चि, p. 18, परा. मा. III. p. 263. In the Introduction to my edition of ENT reconstruction of Katyāyana I have (on pp. VIII-X) pointed out many verses that are common to Katyāyana, Brhaspati, Nārada. and Manu. 
 
-## 38 Katyayana
+## 38 Kātyāyana
 
 496 
 
@@ -9976,7 +9978,7 @@ Kātyāyana himself is named in & verse that is cited from Kātyäyana by Par. M
 
 The number of Smộtis or Smrtikáras quoted or referred to by themselves or mentioned in commentaries and digeste is very large, particularly if one takes into account Sinștikäras or Smặtis with the words 'bphat''madhyama,' 'laghu' and 'vrddha' prefixed to many of them. The important versi fied Smrtis in the Sanskrit alphabetical order will now be briefly dealt with one after another. 
 
-## 39 Angiras
+## 39 Aṅgiras
 
 39. Angiras Angiras is one of the ten primordial sages mentioned in Manusmrti 1.34-35). It is & very ancient oame even in the Rgverle. On Yāj. I. 50 Viśvarúpa quotes a verge of Angiras that what is done according to one's owo will without follow ing the dictates of Sästra is fruitless.578 On Yaj. III. 248 Visvarūpa says that the vrutie called Vajra wu8 prescribed by Angiras for Brähmunas guilty of deadly sins. Visvarūpa (on Yäj. III. 255 ) quotes two verses of Argiras on the prayaścitta for killine the wife of a brähinana who has kindled the sacred fires for killing wives of other brahmanas and ksatriyas and vaisyas. On Yåj. III. 266 he quotes two verses of 
 
@@ -10030,21 +10032,21 @@ The Mitâksarā (on Yáj. 111. 277 ) and the Smştiratnávali of Vedācārya (I.
 
 मिच्छताम् । मातापित्रीर्वा । तन्निमित्तत्वान्मातुरित्येके । अथाप्युदाहरन्ति नाशौचं सूतके पुंसः संसर्ग चेन्न गच्छति । रजस्तत्राशुचि ज्ञेयं तच्च पुति... विद्यते । Compare वसिष्ठधर्मसूत्र IV. 20-23. 
 
+## 40 Ṛṣyaśṛṅga
+
 510 
 
 ilistory of Dharmaśāstra 
-
-## 40 Rsyasrnga
 
 40. Rsyasrnga This is a writer who is frequently quoted on ācāra, āśauca, srāddha, and prāyaścittu by the Mit., Aparărka, Smịticand rikā and other works. A parārka (p. 724 ) quotes as Rsyas roga's a verse ascribed to Sarkha in the Mitāksarā ( on Yāj. II. 119 ) and other works, which states that when one copar cener recovers with his own efforts family property that was lost to the family, he gets a fourth share of it and the others become sharers in the rest.684 The Smrticandrikā (I. p. 32 ) quotes 'api vāsasi yajñopavitārthân kuryāt tadabhāve trivstā sütrena', which is in prose, 
 
 Rsyaśạnga is frequently quoted by Aparārka on the Prāyaścitta section of Yāj. (about 13 verses ) on Prāyaścitta. The Vy. N. of Varadaraja ( p. 26 ) ascribes the verse of Yāj. II. 32 ( Mattonmattārta &c) to Rsyaśşnga also. Aparārka (p. 724 ) quotes one verse of Rsya', on Vyavahāra viz. 'If one coparcener in a joint family recovers by his efforts pro perty lost to the fumily, he should be awarded one-fourth of it and the remaining portion should be distributed among the remaining coparceners according to their proper shares. This verse is ascribed to Saikha by the Smrticandrikā ( on p. 276 ). Kalpataru (on Vy. 622 ) quotes two verses on a wife's duties. 
 
-## 41 Karsnajini
+## 41 Kārṣṇājini
 
 41. Karsnajini This writer is quoted by the Mit. (YĀj. III. 265 three verses ), Aparărka, Smộticandrikī and other works mostly op srāddha. A parārka (p. 138 ) quotes a verse from him which enumerates the seven sons of Bralmă, viz. Sanaka, Sanandana, Sanātana, Kapila, Asuri, Vodha (?) and Panca sikha. A parūrka (p. 424 ) quotes a verse of Kārsnājini which refers to the two signs of the Zodiac, Kanyā, and Vrścikā. 
 
-## 42 Caturvimsatimata
+## 42 Caturviṁśatimata
 
 42. Caturvimsatimata There are two Mgs. of this work in the Bhandarkar Institute, Poona (No. 244 of A. 1881-1882 and 111 of 1895-1902). It contains 525 verses. The work is so called because it embodies the essence of the teachings of 24 sages, Manu, Yājña valkya, Atri, Visņu, Vasistha, Vyāsa, Usanas, Apaskambe, 584 पूर्वनष्टा तु यो भूमिमेकश्येदुद्धरेत् क्रमात् । यथाशं तुं लभन्तेन्ये वाचशित 
 
@@ -10106,7 +10108,7 @@ INS
 
 Series ( Nos. 137 and 139 ). The commentary is a very learned one and refers to a host of writers. This commentary is in some mss. ascribed to Ramacandra ( vide I. O. Cat. No. 1554, p. 473). 
 
-## 43 Daksa
+## 43 Dakṣa
 
 43. Daksa 
 
@@ -10218,7 +10220,7 @@ The Dānaratnākara of Candeśvara cites a prose text from Pulastya on the gift 
 
 The Pulastya-smrti must have been composed between 4th and 7th century A. D. 
 
-## 46 Paithīnasi
+## 46 Paiṭhīnasi
 
 46. Paithīnasi 
 
@@ -10304,7 +10306,7 @@ The Mit. on Yāj. (III. 20, 263, 264 and 265 ), Haradatta on Gautama (22.18 ) an
 
 A few prose quotations from Pracetas are noted in the Smrticandrikā and by Haradatta (on Gautama 23. 1). 
 
-## 48 Prajapati
+## 48 Prajāpati
 
 48. Prajapati Prajāpati is cited as an authority by the Baudhāyana dharinasūtra (II. 4. 15 and II. 10. 71 ). Vasistha several times quotes Prājāpatya blokas (viz. III. 47, XIV. 16-19, 24-27, 30-32). It has been shown above that most of these Verses are found in the Manusmrti or have close correspon dence with verses of Manu. So it is not unlikely that both the writers of dharmasūtras mean Manu by Prajāpati. 
 
@@ -10324,7 +10326,7 @@ FOUNDED
 
 The Mit. (on Yāj. III. 25 and 260 ) quotes verses of Prajā pati on āśauca and prāyaścittu. Aparārka cites verses of Prajāpati on purification of various substances, on érāddha, witnesses, ordeals and āśauca. None of these is traced to the printed text of Prajāpati. A parārka (p. 952 ) gives a long prose text of Prajāpati on the four orders of parivrājakas, viz. kuticaka, bahudaka, hamsa, paramahamsa. Aparārka (p. 542) cites a verge of Laugākṣi which refers to the view of Prajā pati that the son of a putrika was to offer pindas to his mother by the gotra of his maternal grand-father.s13 Aparārka, Smrti. candrikā, Parāśara-Mădhaviya and other works quote several verses of Prajāpati on vyavahāra. Wituesses are of two kinds, krta and akrta.814 In this he seems to have followed Narada (rnadana, verse 149). Prajapati lays down the characteri stics of valid reply ( uttara ) of the defendant and defines 818 the four varieties of uttara. The Parāśara-Madhaviya cites several verses of Prajāpati on ordeals. Prajāpati recognised the right of the sonless widow to succeed to her husband's wealth018 and enjoined on her the duty of offering frāddha every month and year to her husband's manes and to honour his relatives.817 
 
-## 49 Marici
+## 49 Marīci
 
 49. Marici 
 
@@ -10526,7 +10528,7 @@ History of Dharmaśāstra
 
 (lit. killed ) by mere ratiocination (tānyevātipranītāni pa hantavyāni hetubhiḥ ) we should read atipramāņādi for atipranītāni). Ou pp. 243, 270 there are prose passages. On p. 24, it quotes two Upajāti verses. In the Moksakānda Laksmīdhara quotes on pp. 101, 102 five verses of Yama wbich set out the eight prakřtis of the Sārkhya system and the 16 vikstis thereof, the 25th tattva viz. 'a vyakta' and adds Purusottama or Visnu as the 26th (pancavimsakam avyaktam sadviņśaḥ purusottamaḥ 1 Pañcavimšatitattva jño, Yāti Visnoh param padam || In Srāddhakānda Laksmi dhara quotes about 150 verses of Yama ( 17 on pp. 64-65 and 19 on pp. 82-83). Vyavahārakānda quotes about 47 verses of Yama. 
 
-## 51 Laugaksi
+## 51 Laugākṣi
 
 51. Laugaksi 
 
@@ -10546,7 +10548,7 @@ A
 
 Maskarin on Gaut. Dh. S. appears to quote Laugākşi as Lokāksi. On Gaut. 10. 42 ( about the finding of treasure trove) Lokāksi is quoted as "anubhūticibnāni musitvã gļhnataḥ pūrvasāhusam dandah tad-dravya dvigunam ca rājā haret'. Maskarin quotes verses of Lokāksi on Gaut. 14. 1, 15. 1; 22, 18 ( three verses on prāyaścittas for killing a person of pratiloma caste and others also). Kalpataru quotes Laugāksi frequently e. g. on Br. Kānda Laugākşi is quoted five times ( all prose); Kalpao (on Srāddha ) p. 98 defines ' Agredidhuşu and didhisū! 
 
-## 52 Visvāmitra
+## 52 Viśvāmitra
 
 52. Visvamitra Vievāmitra is one of the writers on dharma enumerated by Vrddha-Yājījavalkya as quoted by Visvarūpa. Aparárka, the Smộticandrikā, the Kālaviveka of Jimūtavāhana and other works quote verses of Viśvāmitra on almost all topics of dharma except vyavahāra, such as on the five deadly sins, on srāddhas, prāyaścitta etc. Viśvāmitra defines dharma as that which is esteemed by Aryas ( respectable people who know the Vedas. 640 Aparárka quotes 18 verses from Visvā. mitra on Prayascitta and the Sinrticandrikā also quotes several verses of his Kalpataru ( on Brahmacario), cites Yāj. I. 14 (Garbhāstame &c.) as occurring in Viśvāmitra also. Similarly Kalpataru (on Naiyatakāla p. 314 ) states that Yāj. I. 179 (prānātyaye &c. ) also occurs in Visvāmitra's Smộti. His verses on the mahăpătakas are frequently quoted.641 The Madras (Govt. ) Mss. cat. (p. 1985 No. 2717 ; notices a Smộti of Visvāmitra in verse in nine chapters. 
 
@@ -10680,7 +10682,7 @@ the reply, proof and burden of proof, documents; the judge ment, eight different
 
 Some of the verses quoted as Vyāsa's occur elsewhere e. g. verse 11 ( of the above collection 'na si sabhā...viddham occurs in Nārada III. 18 and is quoted as Vyasa's in Aparārka ( p. 604). Similarly, the verse' na narmayuktam vacanam hinasti ( No. 111 in the list of Dr. Batakrishna Ghosh ) quoted by the Smộticandrikā ( Vy. p. 89 ) as Vyāsa's occurs in the Mahābhārata ( Adi. 82, 16 and Säntiparva 165. 30 ). Verse 129 (Adityacandrāvanilo which is the mantra to be employed in ordeals ) occurs in Adiparva 74. 30. No. 140 of the collection by Dr. Ghosh defines niska as equal to fourteen suvarnas.688 The Mit. on Yāj. I. 72 provides that a wife who drinks wine, who is guilty of adultery with the husband's pupil or guru, who kills her husband and particularly one who has inter course with a man of a degraded caste (such as a shoemaker) should be abandoned.864 So, whoever might have been the author of the Vyāsasmộti he incorporates some verses from the Mahābhārata therein. 
 
-## 54 Sat-trimsan-mata
+## 54 Ṣaṭ-triṁśan-mata
 
 54. Sat-trimsan-mata The title literally means 'the doctrines of thirty-six (Smộtis )'. This appears to have been a work like the Catur vimśatimata. It has been stated above that Paithinasi enumerated thirtysix propounders of Dharma (vide Smrtican driká p. 1). Quotations from Șat-trimsan-mata cited in the 
 
@@ -10720,7 +10722,7 @@ ___ The mit. (quotes about two dozen verses from Sat-trimsan mata on several ver
 
 Krechra penance. 
 
-## 55 Samgraha or Smrtisamgraha
+## 55 Saṁgraha or Smṛtisaṁgraha
 
 55. Samgraha or Smrtisamgraha This work is frequently cited by the Mitākṣarā, Aparārka, the Smộticandrikā and other works on all topics of dharma, The quotations on vyavahāra are copious and are very im 
 
@@ -10814,7 +10816,7 @@ Parāśara, Manu, Yājňavalkya, Yama and Saunaka are cited by naine.673
 
 The Samgraha or Smộtisamgraha inust have contained a very large number of verses, since the Smộticandrikā alone quotes several hundred verses, from it on 'āhnika, Vyavahāra and Srāddha'. The Vyavahāra-nirưaya of Varadaraja states ion p. 324 ) that the view of Sangrahakāra is relied upon by Dhāreśvarabhatta ! 
 
-## 56 Samvarta
+## 56 Saṁvarta
 
 56. Samvarta Saṁvarta occurs as a Smrtikāra in the list of Yājña valkya. He is cited on all topics of dharma by Visvarūpa, Medhātithi, the Mit., Haradatta, Aparirka, the Smộticandrikā and a host of other writers. Visvarūpa quotes either wholly or in part about twenty verses of Samvarta on evening sandhyā vandana, on the duties of a yuti and on the prāyaścittas for theft, adultery of various kinds, deadly sius. Medhātithi quotes verses of Surivarta on Manu V. 88 and XI. 116. The Mit. quotes him on prayascitta and aśauca ( Yāj. III. 6. 17 19 etc. ). Apararka had a large work before him and quotes about 200 verses almost all on īcīra and priyuscitta. 
 
@@ -10866,7 +10868,7 @@ The Mit. quotes a Bphat-Saṁvarta (on Yāj. III. 265 288 ).
 
 A Svalpa-Sarvarta is quoted in Harinātha's Smrtisāra. 
 
-## 57 Harīta
+## 57 Hārīta
 
 57. Harīta The verse quotations from Hārīta on topics of vyavahāra deserve some treatment. He defines vyavahāra as that where by the recovery of one's own wealth and the avoidance of (doing ) the duties peculiar to another (caste or class ) are effected in due course of law.878 He further says that that judicial proceeding is proper which is based on the dictates of dharmaśāstra and arthasāstra, which is in conformity with the usages of respectable people and which is free from fraud.978 Hārita calls upon the king to know the sāstras, the 
 
@@ -11102,7 +11104,7 @@ FOUNDED
 
 The Vivādaratnākara 03 (p. 578 ) quotes the Prakāśa as refer ring to the views of Asahāya and Medhātithi on Manu IX. 198 that the special rule of Manu applies to all the stridhana belonging to a Ksatriya woman who has a brāhmani co-wife. The Vivādaratnākara704 quotes a verse of Nārada about māsa and a verse of the blāsyakāra thereon. It probably refers to Asahāya's bhāsya. 
 
-## 60 Bhartryajna
+## 60 Bhartṛyajña
 
 | áo. Bharteyajĩa This seems to have been a very ancient commentator. Medhatithiros in his bhāsya on Manu 8. 3 says 'other explana tions have been well brought out by Bhartļyajña and they should be understood from his work'. Trikānda-mandana (who flourished before 1100 A. D.) in his Āpastambasūtra dhvanitārtha-kāriki708 (I. 41) refers to the views of Bhartr yajña that one who had committed to memory the text of the Veda had the privilege ( the adhikāra ) of consecrating the sacred fires, though he may be innocent of the meaning of the Vedic texts. From Ananta's bhâsya it appears that Bhartryajña composed a bhāsya on the KĀtyāyanaśrautasūtra which had been lost (autsanna) in the former's day. From Gadūdhara's comments on the Paraskaragrhyasūtra it appears that Bhartryajña commented on Päraskara,707 The Grhastha ratnākara of Candeśvara quotes Bhartsyajña’s explanation of 
 
@@ -11142,7 +11144,7 @@ p. 12. 710 873 a fullar ureterala HTAT: 1 TEM PAT folio 133,61. Višvarūpa
 
 Since Bhartryajña is quoted by Medhătithi who also men tions Asahāya but not Viśvarūpa, it follows that Bhartryajia must have flourished before 800 A. 1), and was probably & contemporary of or slightly later than Asahāya. 
 
-## 61 Viśvarupa
+## 61 Viśvarūpa
 
 61. Viśvarupa The commentary of Viśvarūpia called Bālakrīdā on the Yājsavalkya-smrti has been recently published in two parts by M. M. T. Ganapati Sāstri in the Trivandrum Sanskrit Series. The Mit. states in the introductory verses that the dicta of Yij. were expanded by the voluminous or ample (vikata ) explanations of Visvarüsra. In commenting on Yāj. 1. 81 the Mit. tells us that Visvarūjia looked upon the words of Yāj. I. 79 ( tasmin yugmāsu saṁviset ) as a niyama. In Visvarūpa's commentary on Yāj. I. 80 (evam gacchan &c. ) we do find that the verse of Yāj. and similar passages of Manu (3. 45 ), Vasistha and Gautama ( 5. 1 ) are understood to contain a niyam and not a prescinkhyu.?!! On Yāj. III. 24 the Mit, inforins us that Visvarūpa, Medhatithi and Dhāre svara looked upon certain texts of Rsyasriiga on āściucu as in conflict with well-known sinitis and discarded them. Mr. S. Sitaram Sústri published (in 1900 at Madras ) the text and translation of Viśvarūpia's comment ou inheritance and Mr. Setlur also published the wavahürco section. In the following pages the Trivandrum edition is relied on. 
 
@@ -11570,7 +11572,7 @@ Grafy CET AT TIET JETA waf hf 31180 11 ... 3747 Branca पठ्यन्त ए
 
 whole of Bharuci's available text is printed and carefully studied. Vide remarks under Sarasvativilāsa of Prataparudra deva for various passages of Bharuci referred to and Manu, particularly VII. 13. 
 
-## 63 Srikara
+## 63 Śrīkara
 
 63. Srikara The Mit. on Yāj. II. 135 alludes to the view of Srikara and others that the widow succeeded is heir to her deceased husband's estate if it was small.743 The Smytisära744 of Harinātha attributes the same view to Srikara and disappro ves of it. On Yāj. II. 169 the Mit.746 cites the view of Srikara about that topic and disapproves of it. Visvarūpa also gives two explanations of that verse of Yāj., the first of which agrees with that of the Mit, and the second is akin to Srikara's. 
 
@@ -11624,7 +11626,7 @@ This Srikara must be distinguished from another Srikara, the father of Srinātha
 
 1 
 
-## 64 Medhatithi
+## 64 Medhātithi
 
 64. Medhatithi Medhatithi is the author of an extensive and erudite commentary ( bhusyu ) on the Manusmrti. It is the oldest extant commentary on that smrti. The bhâsya of Medhătithi was first published about forty years ago by Rao Saheb V. N. Mandlik in Bombay and recently Mr. J. R. Gharpure of Bombay brought out an edition of Medhātithi which closely follows Mandlik's edition. A critical edition of the bhāsya based upon all the available Msg. is a great clesideratum. A new edition in two volumes based on several mss. edited by M. M. Dr. Ganganath Jha was published in the G. O. I. Series in 1932 and 1939. In this edition also ten verses in the 3rd adhyāya are wanting and in adhyāya nine there 
 

--- a/kANe/v1p1.md
+++ b/kANe/v1p1.md
@@ -50,6 +50,8 @@ Hon. Secretary, Bhandarkar Oriental
 
 Resourol Institute, Poona 4 
 
+## 00 Preface
+
 PREFACE 
 
 On November 17, 1962, the publication of the fifth and last Volume of Professor P. V. KANE's History of Dharmasastra was formally announced by Dr. S. RADHAKRISIINAN, and a significant landmark in the history of Indological research in this country may be said to have been thereby established. The Histury of Dhramuśīstru is a literary work which is. truly magnificent both in conception and execution. Its five Volumes, which together extend over nearly 6,500 pages, seek to present the most comprchensive treatment of the religious and civil law of ancient and medieval India. And, Professor KANE has accomplished this gigantic task single-handed incidentally, he has written down every word in the History in his own hand --and that too while he had been occupied with various other literary and public activities. As I have said on another occasion, for Professor KANE, the History of Dharma śāstra is the crowning glory of a life of great fulfilment, and, for the Bhandarkar Oriental Research Institute, it is a matter of signal pride and honour to have been closely associ ated with that work. 
@@ -79,6 +81,8 @@ FOUNDED
 1917 
 
 TIT 
+
+## 00 List of Abbreviations
 
 LIST OF ABBREVIATIONS 
 
@@ -178,6 +182,8 @@ A
 
 HISTORY OF DHARMASĀSTRA, 
 
+## 01 Meaning of Dharma
+
 1. Meaning of Dharma 
 
 Dharma is one of those Sanskrit words that defy all attempts at an exact rendering in English or any other tongue. That word has passed through several vicissitudes. The dictionaries set out various meanings of Dharma such as “ordinance, usage, duty, right, justice, morality, virtue, religion, good works, function or characteristic." Dharma is also personified as a doity, as in the well-known verse. Adityacandrāvanilosnalasca... dharmaśca jānāti narasya vṛttam'(Mahābhårata, Adi., chap. 74.16) or as in Manusmrti VIII. 16 .vřso hi bhagavān Dharmah' ( which also occurs in Sāntiparva 90.75 ). Vide H. of Dh. Vol. V (part 1) pp. 19-21 for the three words "vrata', 'dharman' and 'rta' and JBBRAS. Vol. 29 (1954) pp. 1-28. In the hymns of the Rgveda the word appears to be used either as an adjective or a noun (in the form dlarman, generally neuter) and occurs at least about sixty times by itself (i. e, not preceded by a particle like vi or some words like satya), and about eighteen times in combination with a particle 'vi' and with the words *sva' and 'satya' fifty-six times therein. It is very difficult to say what the exact meaning of the word dharma was in the most ancient period of the Vodic language. The word is clearly derived from root dh? (to uphold, to support, to nourish ). In a few passages, the word appears to be used in the sense of up holder or supporter or sustainer' as in Rg. I. 187.11 and X. 92.22. In these two passages and in Rg. X. 21.33 the word dharma is clearly masculine. In all other cases, the word is either obviously in the neuter or presents a form which may be either masculine or neuter, In most cases the meaning of dharman is religious ordinances or rites 'as in Rg. I. 22. 18, V. 26. 6, VIII. 43. 24, IX. 64. 1 &c. The refrain'tani dharmāni prathamânyåsan' occurs in Rg. I. 164. 43 and 50, X. 90. 16. Similarly, we have the words 
@@ -247,6 +253,8 @@ This is not the place to discuss what Asoka's Dhamma was, From tbe 4th Rock Edic
 History of Dharmaśāstra 
 
 The present work will deal with the sources of dharma, their contents, their chronology and other kindred matters. As the material is vast and the number of works is extremely large, only a few selected works and some important authors will be taken up for detailod treatment. More space will he dovotod to comparatively early works. 
+
+## 02 Sources of Dharma 
 
 2. Sources of Dharma The Gautamadharmasūtra?? says 'the Veda is the source of dharma and the tradition and practice of those that know it (the Veda ).' So Äpastamba18 says the authority (for the dharmas ) is the consensus of those that know dharma and the Vedas.' Vide also the Vasisthadharma-sūtra 19 (I. 4-6). The Manusmộti20 lays down five different sources of dhurmu “the whole Veda is (the foremost) source of dharma and (next) the tradition and the practice of those that know it (the Veda); and further the usages of virtuous men and self-satisfaction.' Yájña valkya21 declares the sources in a similar strain the Veda, traditional lore, the usages of good men, what is agreeable to one's self and desire born of due deliberation-this is traditionally recognised as the source of dharma.' These passages make it clear that the principal sources of dharma were conceived to be the Vedas, the Smrtis, and customs. The Vedas do not contain 
 
@@ -363,6 +371,8 @@ Recently (1959) Dr. Ram Gopal has brought out a large work on 'India of Vedic Ka
 .!!!12 
 
 History of Dharmaśāstra 
+
+## 03 Date of Dharmasastra works
 
 3. When Dharmasastra works were first composed 
 
@@ -530,6 +540,8 @@ The gļhyasūtras belonging to the Sāmaveda are :
 
 The Atharvaveda has the Kausika-sūtra as its Grhya. which was edited by Prof. Bloomfield. Vide Prof. Belvalkar Presentation Vol. pp. 28-33 for a paper by Mr. O. G. Kashikar for corrections in it and a paper Kausikasūtra and the Atharva veda' by Prof. Edgerton in F. W. Thomas Presentation Vol. pp. 78-81. There are several commentaries on it. It devotes a large part of it to utpūtas and sūntis. 
 
+## 04 The Dharmasutras
+
 4. The Dharmasutras It seems that originally many, though not all, of the dharma. siiras formed part of the Kalpasūtras and were studied in distinct sūtrucaranas. Some of the extant dharmasūtras here and there show in unmistakable terms that they presuppose the Gshyasūtra of the caraņa to which they belong. Compare Āp. Dh. S. I, 1. 4. 16 with Ap. Gș. S. I. 12 and II. 5; and Baud. Dh. S. II. 8. 20 with Baud. Gr. S. II. 11. 42 (and other sūtras ).54 The Dharmasūtras belonging to all sūtracaraṇas have not come down 
 
 54 अमिमिद्ध्वा परिसमूह्य समिध आदध्यात् सायं प्रातर्यथोपदेशम् । आप. ध. स. 
@@ -573,6 +585,8 @@ faifa AT' and 0119. 47. 7. 11. 6. 13. 9 az-a127 aghia: e22
 History of Dharmaśāstra 
 
 are given in the H. of Dh. Vol. II where they are explained ; āghārau (p. 1051 n. 2360), Ajyabhāga (p. 1059 n. 2371), Abhi ghārana (p. 528 n), Avadāna (528, 1061 n), Upastarana (p. 1061 n), Pavitra ( 211 n., 1021 n), Paryagnikarana (p. 1120 n), (Pranītā p. 1022-23), Pratyabhighārana (p. 1053 n). The Āp. Dh. S. (I. 4. 12. 10 ) makes the interesting statement "religious rites were declared in the Brāhmaṇas, the texts of those rites have been lost, (but those texts ) can be inferred from the actual per formance (of the rites that are in vogue): "brāhmanoktā vidhayas teşām utsannāḥ pathāḥ prayogād-anumiyanto'. This shows that an early writer like Apastamba (who flourished some centuries before the Christian era ) was aware that Brāhmaṇa works had once described many of the gļhya rites, but that in his day such Brāhmaṇa texts had been lost. 
+
+## 05 The Dharmasutra of Gautama
 
 5. The Dharmasutra of Gautama. This has been printed several times (there is Dr. Stenzler's edition of 1876, the Calcutta edition of 1876, the Ānanadāśrama edition with the commentary of Haradatta, and the Mysore Government edition with the bhāsya of Maskarin ; it was trans lated by Bühler in S. B. E., Vol. II. with an introduction). The Anandāśrama edition of 1910 which is incorrect in a few places (e. g. 21.7 ) has been used in this work. This dharmasūtra is, as we shall see, the oldest of those we have. The Gautama dharmasūtra was specially studied by followers of the Sāmaveda ( see note 55 above). The commentary on the Caranavyuha tells us that Gautama was one of the nine sub-divisions of the Rānāvanīya school of the Sāmaveda. A teacher Gautama is mentioned frequently in the Lātyāyanaśrautasūtra (. g. I. 3.3 and I. 4. 17 ) and in the Drähyāyanaśrauta (e. g. I. 4. 17, IX. 3. 15 ) of the Sāmaveda. The Gobhilagphya (III. 10.6) which belongs to the Sāmaveda cites Gautama as an authority. There fore it is not improbable that a complete Gautamasutra embody ing Srauta, Grhya and Dharma doctrines once existed. There are other indications pointing to the close connection of the Gautamadharmasūtra with the Sāmaveda. Chapter 26 of the dharmasūtra about Krcchra penance is the same, almost word for word, as the Sāmavidhānas9 Brāhmaṇa (I. 2, Burnell's ed.). 59 There are, however, considerable divergences; e. g. tit. 17. 9. 26. 10-12 
 
@@ -894,6 +908,8 @@ such usages of countries, castes and families are valid and authoritative as are
 
 The Mitāksarā, the Smộticandrikā, Hemādri, Madhava and (ther writers quote a sloka-Gautama. Vide Parāśara-Madhaviya, vol. I, part I, p.7. Aparārka, Hemādri and Mādhava quote VỊddha-Gautama, while the Dattakamimāṁsā (p. 72 ) quotes Vrddha-Gaut. and Brhad-Gaut. side by side on the same point. These are later works. Jīvānanda publishes a smrti of Vrddha Gautama in 22 chapters and about 1700 verses (part II, pp. 497 636 ), where it is said that Yudhisthira asked Krsna about the charias of the four castes. This smrti seems to have been originally taken from the Āývamedhikaparva of the Mahābhārata, as Mādhava and others cite verses occurring in it as from that parya ( vide Parāśaramadhaviya vol. I, part I, pp. 108-110 ). 
 
+## 06 The Baudhāyana Dharmasutra
+
 6. The Baudhāyana Dharmasutra This has been edited several times (text by Dr. Hultzsch at Leipzig in 1884, text in the Anandāśrama collection of smrtis and in the Mysore Government Oriental Series in 1907 with the commentary of Govindasvāmin; translated in S. B. E., Vol. 14, with an Introduction). The Mysore edition has been used in this work. Baudhāyana is a teacher of the Krsnayajurveda. A complete set of the Baudhāyanasñtras has not yet been recovered and has not been as carefully preserved as the sūtras of Apa stamba and Hiranyakesin. Dr. Burnell arranges Baudhāyana's sütras into six sūtras, the Srautasütra in 19 praśnas (probably ); Karnāntasūtra in 20 adhyāyas ; Dvaidhasūtra in four prašnas ; Grhyasūtra in four praśnas ; Dharmasútra in four praśnas ; Sulvasūtra in three adhyāyas. The commentators offer no indi cation as to the place originally assigned to the grhya, dhurma and sulva sutras in the whole collection. Dr. Caland in his mono graph ( A. D. 1903 ) 'Uber das Rituelle sūtra des Bandhayana' gives on p. 12 the contents of the Baudhāyanasūtra as follow: Praśnas I-XXI Śrauta, XXII-XXV Dvaidha, XXVI XVIII 
 
 6. The Bandhāyana Dharmasutra 
@@ -1107,6 +1123,8 @@ datos are more or less tentative and there is n10 finality about them at least a
 In the tarpana, Baud. (II. 5. 21 ) mentions several appellations of Ganesa, viz. Vighna, Virāyaka, Sthüla, Varada, Hastimukha, Vakratunda, Ekadanta, Lambodara. But this affords no certain clue as to date. The worship of Vināyaka is found in tho Mänavagļhya also. In the tarpeixe (II. 5. 23 ) we have the seven planets montioned in the order of the days of the week and also Rāhu and Ketu ; besidos the twelve names of Visnu occur in II. 5. 24. In II. 1. 44 Baud. speaks of tho profession of an actor or of a teacher of dramaturgy (Natyācārya) as an upapătaka. Soveral sūtras attributed to Baudhāyana on the subject of adoption in the Dattakamimāmsā and other later works are taken from the Baudhāyanagrlyasoșasūtra (11. 6), the gūtras agreeing very closely with Vasistha ( 15.1-9). 
 
 According to Burnell the oldest commentator on the Baudhāyanaśrauta-sūtra was Bhavasvāmin, whom he placed in the 8th century. The commentary of Govindasvamin on the Dharmasūtra is a learned one and is generally to the point. He appears to be a very late writer. 
+
+## 07 Dharmasutra of Āpastamba
 
 7. Dharmasutra of Āpastamba. This has been edited several times (viz. by Bühler in the Boinbay Sanskrit Series with large extracts from Haradatta's commentary called Ujjvalā and also at Kumbhakonam with the complete commentary of Haradatta and translated by Bühler with an introduction in S. B. E. vol. II). The Apastan bakalpasūtra of the Taittiriya Sākhā of the black Yajurveda is divided into 30 pruśnas. According to Bühler, the first 24 praśnas contain the treatment of Srauta sacrifices; the 25th contains paribhūṣās, pravarakhanda, and Hautraka prayers to be recited by Hotr priests ; 26th and 27th praśnas constitute the Gșhyasūtra, the 28th and 29th Dharmasūtra and the 30th praśna is Sulvasútra. Bühler seems to be slightly inaccurate here. According to Caundappa, who commented on the Āpastambiya sūtras in the 14th century, the Āpastambiyaman trapātha forms the 25th and 26th praśnas of the Kalpasūtra and the Gșhyasūtra forms 27th prasna.80 The Srauta-sūtra of 80 पंचविशेष षइविंशे गृहमन्त्राः प्रपञ्चिताः । प्रश्नेथ सप्तर्विशे स्याब्रह्मतन्त्रविधिक्रमाती 
 
@@ -1704,6 +1722,8 @@ Shri. A. N. Krishna Aiyangar in Kunhan Raja Felicitation Volume (pp. 392–397 )
 
 27 
 
+## 08 Hiranyakeši-Dharmasūtra
+
 8. Hiranyakeši-Dharmasūtra 
 
 8. Hiranyakosi-dharmasūtra. The Hiraụyakeši-dharmasūtra forms the 26th and 27th praśnus of the Hiranyakeśi-kalpa. The Srauta-gütra has been published by the Anandāśrama Press (Poona ). The Hiranya koši-gļhya-sutra was edited with extracts from the cominentary of Mātrdatta by Dr. Kirsto ( Vienna, 1889). The Gșhya forms the 19th and 20th praśnas of the Kalpa, each praśna being divided into eight patalas. The Srauta-sūtra is largely based on the Srauta-sūtra of Āpastamba Tho Gșhya-sūtra is indebted to the Gļhya-sutra of Bhäradvāja. The Dharmasutra of Hiranyakośin can hardly be called an independent work. Hundrods of sūtrus are borrowed word for word from the Apas tambil Dharınasūtra. The Dharnasūtra of Hirapyakešin ia therefore the oldest voucher for the authenticity of Apastamba's text and is very valuable for checking the latter. 
@@ -1759,6 +1779,8 @@ Rhanus
 History of Dharmaśāstra 
 
 in the Hiraṇyakeši school; e. g. he comments on 'padūnam', ou *adhasanašāyi' for ardhāsanašāyi (the reading of the sūtra ), on 'ātmasvastyayanārthena' (Ap. II. 5. 11. 9 ) for svastyaya lārthena' of the ms. of Hir. The explanations of the two writers sometimes differ, as for example on ācāryādhinas syād anyatra pataniyebhyah' (Ap. I. 1. 2. 19104). One more circum stance that is worthy of note is that the Ujjvalā of Haradatta does not contain many quotations from Smộtis as compared with his commentary on the Gautamadharmasūtra. Although ono may be inclined to hold that it is Mahādova who borrows, it inust be clearly recognized that there is hardly any positivo evidence in support of such a view. There is a commentary called Vaijayanti on the Hiranyakesi-srauta-sūtra. This Malādeva is very likely identical with the Mahadeva who commented upon the dharmagūtra. 
+
+## 09 Vasistha-dharmasutra
 
 9. Vasistha-dharmasutra. This dlurmusutra has been printed several times. The collec tion of Jivanada (part II, pp. 456-496 ) contains only 20 chapters and a portion of the 21st and so does the collection of Mr. M. N. Dutt (Calcutta 1908). The Anandāśrama collection of sinītis ( 1905, pp. 187-231 ) and the edition of Dr. Führer in the B. S. series (1916) contain thirty chapters. According to Dr. Jolly (R. u 8, p. 6 ) some mss. give only six or ten chapters, The Vasisthadharmasütra with the commentary called Vidvan modini was printed at Benares. In the following Dr. Führer's 
 
@@ -2050,6 +2072,8 @@ prose passage. The Kalpataru profusely quotes Vasistha in Gșhasthakāņda ( 41 
 
 That Yajñasvāmin wrote a commentary on the Vas. Dh. S. follows from Govindasvāmin's comment on Baud. Dh. S. (II. 2.51), where he quotes Vas, 21. 13 and Yajñasyāmin's comment thereon. 
 
+## 10 Visnudharmasutra
+
 10. Visnudharmasutra. The Vişnudharmasūtra has been printed several times in India, viz. by Jivananda in his Dharmasastrasangraha (1876 part I pp. 70-176 ) by the Bengal Asiatic Society (1881, ed. by Dr. Jolly with extracts from the commentary Vaijayanti ), by M. N. Dutt (Dharmaśāstra texts, vol. II pp. 541-666, Calcutta, 1909) and translated by Dr. Jolly (in the S. B. E. vol. VII with an Introduction). In the present work Dr. Jolly's edition has been used. The gūtra contāins one hundred chapters. Though the number of chapters is so large, the sūtra is not very extensive. There are several chapters such as 40, 42 and 76 that contain only one sūtra and one verse. The first chapter and the last two are entirely in verse; the remaining chapters are in mixed prose and verse, the versified portion being generally at the end of each chapter. As pointed out by the Vaijayanti the sūtra is in close relation to one of the oldest schools of the Yajurveda, viz. Katha. It also stands in a peculiar relation to the extant Manusmộti. According to the Caranavyūha, Kathmand 
 
 1917 
@@ -2286,6 +2310,8 @@ From the fact that the Sarasvativilisa quotes several times the sutras of Visnu 
 
 So far only the printer and well-known Jharmasūtras have been passed under review. But there were numerous other dharmasūtras which are either noir extant in rare m88. or are not yet discovered but are only to be reconstructed from quotations. It is now time to discuss them. 
 
+## 11 The Dharmasutra of Harita
+
 11. The Dharmasutra of Harita That Hārīta was an ancient sūtrakāra on dharma is quite patent from the fact that the dhurmasitras of Baudhå. yana, Apastamba and Vasiştha quote him as an authority. 
 
 118 6.g. para 637 : JUTE potrafavaraanageTAAT aftage: fouse 
@@ -2476,6 +2502,8 @@ Dr. S. C. Banerjee in J. O. I. ( Baroda ) vol. VIII pp. 14-37 ( 1958 ) published
 
 If all passages of Hārīta quoted in the several nibandhas were collected and carefully studied it would be found that several verses are common to it and Manu and other smộti kāras. For example, Kalpataru (op Grhastha ) p. 43, noted that the verse Vrsalīphenapītasya' is common to Manu, Yama and Hūrīta (it is Manu IV. 19). The same kända on p. 310 quotes with the word ('evam hyāha') three verses one of which ( pañca paśvanyte hanti) is the same as Manu VIII. 98. 
 
+## 12 The Dharmasutra of Sankha-Likhita
+
 12. The Dharmasutra of Sankha-Likhita From the Tantravārtika we learn (note 55 above ) that the Dharmasūtra of Sankha-Likhita was specially studied by the Vājasaneyins ( the followers of the white Yajurveda ). The Tantravārtika also quotes a few words from thnt Dhar. masūtra which constitute an Anustubh pada.138 The Mahá bhārata ( in Säntiparvan, chap. 23. 18-43 ) narrates the story of the two brothers, Sankha and Likhita, who resided in sepa rate dwellings surrounded by trees. Once Likhita came to the ábrama ( hermitage ) of Sankha in his absence. He took some ripe fruits from some of the trees of Sarkba's aśrama and ate them. While he was eating, Saikha came and asked him where he got the fruits. Likhita smiled and told his brother that he took them from his trees. Then Sarkha got angry and told his brother that he was guilty of theft and asked 
 
 131 taon na H21 JmT: I ho fa cremat ro f 3: 1 
@@ -2602,6 +2630,8 @@ HET II. 141. 143 ' Tefat 77 gala za trant van' quoted in PCT. HISZEN
 
 p. 98. Compare \#9 8. 44 
 
+## 13 Mānavadharmasutra
+
 13. Mānavadharmasutra-Did it exist? 
 
 143 
@@ -2687,6 +2717,8 @@ the independent authority of Kalpasūtras. It appears that ..the Mänava school,
 early. Kumărila, who was a most learned and profound stu dent of the various branches of Sanskrit literature, nowhere mentioned the Mänavadharmasūtra as studied by followers of the Black Yajurveda, though he mentions Baudhāyana and Apastamba as studied by them. He places the Manusmrti even higher than the Gautamadharmasūtra and betrays no knowledge of the existence of the Mānavadharmasūtra. Vißva rūpa who is generally identified with Sureśvara, the pupil of Sankara, remarks that the Mänavacarana is not existent (or found ) 160 
 
 The foregoing discussion will, it is hoped, induce every impartial critic to endorse the conclusion that, on the materials so far available, the theory that the Mānavadharmasūtra once existed and that the extant Manusmrti is a recast of that Būtra must be held not proved. 
+
+## 14 The Arthasastra of Kautilya 
 
 14. The Arthasastra of Kautilya 
 
@@ -4542,6 +4574,8 @@ Asvastana'i. e. storing only as much corn as would suffice for a day or he may f
 
 FOUNDED 7 
 
+## 15 Vaikhānasa-dharma-prasna
+
 15. Vaikhānasa-dharn-prasna 
 
 257 
@@ -4603,6 +4637,8 @@ Other Sutra Works on Dharma It will be proper to say a few words about some othe
 261 
 
 individual cases they inay really belong to a later age than the works composed entirely in verse. They will be taken up in alphabetical order (Sanskrit ). 
+
+## 16 Atri
 
 16. Atri That Atri was an ancient writer on hurma follows from & reference to him in Manu (III. 16 ) as holding the view that a crijati taking as wife a südra woman became fallen (patita). In the Deccan College collection there are several mss. ( Nos. 185-187 of A 1881-82 ) of the Atreyadharmaśāstra in nine adhyayas. They trent of gifts, prayers (japya ) and tupus by which men are free from all sins. Some of the chapters are in mixed prose and verse. The first three chapters are entirely in verse and some of the verses (such as ekāksaram param brabma) occur in the Manusmști. The fourth opens with a long sūtra, which, in style, resembles later bbāsyas and com mentaries, 320 The 5th also is in verse and contains several verses found in Viisistha ( Dh. S. 28. 1, 4, 6). The sixth speaks of the specially boly hymns and verses of the Veda. Some of the verses here are the same as Vasistha ( 28. 10–11). "The seventh refers to secret prayascittas and the very first sūtra after the opening words sj.eaks of several non-Aryan tribes 230 such as the Sakas, Yavanas, kambhojus, Balbikas, Khusus, Vangus aud Pärasu ( Persians ? ) &c. It is to be noted that the saine sutra ( with slight variations ) is quoted as Atri's by Apariirka (on Ynj. III. 266 p. 1123). The 7th aud 8th chapters are in inixed prose and verse. The 9th is in verse and speaks of Yoya and its unyus. It refers to the fact that Sisupūlu, son of Damaghosa, because in his hatred of Govinda he always thought of the latter, went to heaven. The same sutra work is noticed in I. O. Cat., pp. 380-81, Nos. 1305 and 1306. 
 
@@ -4671,6 +4707,8 @@ History of Dharmasastra
 Aparārka quotes about a hundred verses of Atri on vari ous topics. Aparırka quotes (on Yāj. III. 61 pp. 966-7) twelve verses of Atri on the repetitions of om, prānāyāma, and the virtues to be practised by him who desires to go into samādhi, 7 verses on Yāj. III. 64 pp. 971-72 on 24 tattvas and purusa as 25th ; on p. 1123 a prose passage on prāyaścitta for partaking of the food of or receiving gifts from actors, dancers and Andhras, Dramidas, Sukas, Kambhojas, Tukk hāras, Valhikas and Khaśas. Sarkarācārya on V. S. III. 40-43, quotes two verses from Smitis, one of which · Arūdho naisthi kam karma &c.' occurs in Atrismộti VIII, 16 ( Anan. edition ). 
 
 Mr. A. N. Krishna, Aiyungar edits an Ātreya-smrti in Adyar Library Bulletin, vol. VI, part 4. 
+
+## 17 Usanas
 
 17. Usanas Kāvya Uśanas is an ancient sage in the Rgveda ; vide æg. I. 83. 5, where Kavya Uśanas is said to have been an helper of Indra and brought out the cows (carried away and concealed by the Panis). In Rg. VIII. 23. 17 that sage is said to have established Agni for Manu and in Rg IX. 87. 3 Ušanas is called a řsi and vipra and one who knew the hidden place where cows were concealed. 
 
@@ -4864,6 +4902,8 @@ SITO
 
 11 FOUNDED 
 
+## 18 Karva and Känva 
+
 18. Karva and Känva 
 
 273 
@@ -4889,6 +4929,8 @@ VO
 274 
 
 History of Dharmasastra kämya, vrddhisrāddha and pārvana ), XI. 18 (verse viz. pūrvajanmakrtam karma daivamityabhidhiyate ), XV. 17 (verse), XVII. I ( verse on Stridhana ), XV. 3 (three verses on prayascitta). 
+
+## 19 Kasyapa and Kasyapa
 
 19. Kasyapa and Kasyapa Baudhayana ( Dh. S. I. 11. 20) cites a verse which con tains the view of Kaśyapa that a woman who is bought can. not be a patnī and that she is not authorised to take part in religious ( daiva ) rites or rites for the Manes.254 This verse is ascribed to Katyayana in the Smrticandrika ( I. p. 87 ). The Vanaparva quotes gāthcs of Kāśyapa on forbearance ( 29. 35-40). Whether Kaśyapa and Kāśyapa are two different writers of dharmasútras it is rather difficult to say. Probably they are identical. It appears that the dharmasútra of Kāśyapa comprised all the usual topics of dharmasūtras, such as daily duties, sraddha, asauca, prayascitta. This sutra has been quoted by all eminent writers from Visvarūpa down wards. Visvarāpa quotes Kasyapa (in prose ) on the priya scitta for contact with candila 8866 and for killing a cow when the sinner is a brāhmana or a member of another caste. 288 The Mit. (on Yaj. III. 23) quotes a prose passage from Kāsyapa on freedom from impurity on death of infants.257 The quotations in the Smộticandrikā on ähnika and traddha are all in verse. Haradatta on Gautama (22. 18 ) quotes a sūtra on the prāyaścitta for govadhu, 258 which is also quoted by Visvarūpa. Haradatta (on Gaut. 23. 26 ) quotes a very long sūtra on the prāyascittu for eating several things and doing 
 
@@ -4942,6 +4984,8 @@ Prof. T. R. Chintamani contributed a paper (in which he edited a Dharma--śāstr
 
 It is to be noted that Käśyapa is not mentioned by Yáj. as one of the dharmaśāstraprayojakas, though Parāśara (chap. I. 13) mentions Kāśyapă dharmāḥ. The Smộticandrikă (I. p. 1) and the Sarasvativilāsa (p. 13 ) speak of 18 Upasmrtis in which Kāśyapa's is included. 
 
+## 20 Gārgya
+
 20. Gārgya Višvarūpa (on Yaj. I. 4-5) quotes a verse of Věddha Yájñavalkya in which Gärgya is enumerated among the expo unders of Dharma ( dharmavaktūraḥ). He quotes two sūtras, one from Gárgya ( on Yāj. I. 72260 ) and the other from Vțddha Gārgya361 (on Yâj. I. 195). Therefore it seems that a sutra work of Gárgya on dharma did exist. The Mit. (e. g. on Yāj. III. 326 ), Aparārka and the Sinșticandrika quote several verses of Gārgya on õhnika, śräddha and práyascitta. Parā sara (I. 13) mentious Gárgya among writers on dharma. Apa rārka contains (pp. 124, 190, 368, 544 ) verses from Gárgya on topics of dharina. It seeins that the two writers are identical. Aparārka also quotes several verses from Gārgya of astrono mical import (e. g. p. 5:17 on the nomenclature of the months as Caitiu in connection with the signs of the zodiac). This was probably an independent work. Fragments of a Gärgi samhiti on astronomy and astrology have been recovered and it contains valuable historical information ( vide Kern's pre face. to Brhat-samhită pp. 33-40 and Mr. Jayasval in JBORS. vol. 14, p. 397 (F). A Jyotir-Gärgya and a Brhad-Gārgya are quoted in the Smộticandrikā. The Nityācārapradipa (p. 20, B.I.S.) mentions Garga and Gārgya separately as smștikāras. 
 
 280 gfaar: fra FUIFFT Wararaarent al zer अनेकोद्धार्ये काष्टशिले भूमिसमे। . 
@@ -4949,6 +4993,8 @@ It is to be noted that Käśyapa is not mentioned by Yáj. as one of the dharma�
 FOUNDE 
 
 1917 
+
+## 21 Cyavana 
 
 21. Cyavana 
 
@@ -4971,6 +5017,8 @@ AM
 History of Dharmaśāstra 
 
 Rg. Mantras and on pp. 1103, 1190, 1199 provides expiation (in prose) for causing the death of a cow, for one who touches or carries to tbe cemetery or cremates a suicide, and for close contact of Cāudālas with houses, earthenots and states that for children, the ayed and women the expiation is only half of what is prescribed for grown-up inen. Apurárka quotes only one verse on Yáj. III. 264-265 as mild expiation in cer tain cases of causing the death of a cow. The Mit. on Yāj. III. 30 cites a long prose passage as regards the times when a bath with clothes on is necessary. 
+
+## 22 Jatukarnya
 
 22. Jatukarnya 
 
@@ -4997,6 +5045,8 @@ FOUNT
 and later writers are in verse and so it appears that by that time the work had been lost or forgotten. Aparārka (p. 423 ) quotes a verse of Jātükarnya which refers to the zodiacal sign Virgo. This would place the verse Jätükarnya not very much earlier than the 3rd or 4th century A. D. 
 
 Maskarin on Gaut. Dh, S. quotes, on different sūtras, a number of verses e. g. on 10. 61 (three verses ), 14. 31, 15. 1, 21. 3, 22. 20-21 (two verses ), 22. 36 &c. The Smrti-can drikā quotes verses of Jātukarıya five times on Ahnika and twelve times on Sraddha and a prose passage ( Alnika p. 114, Gharpure's ed.) on what is meant by Uttariya (in Srauta or Smärta rites ). Aparārka (p. 1069 on Yāj. III. 253 ) quotes a verse of J. that if a boy whose upanuyanu had not been perfo rmed drinks by mistake liquor the prayascitta is three krc chras to be undergone by the boy's mother, brother or father. Visvarūpa quotes several prose passages of Jātākarụya ( vol. 1. pp. 7, 46, 48, 144 on Sraddha), while Mit. quotes several verses on Yāj. I. 256, III. 17, 30, 253, 259-60. The name Jātükarnya is an ancient one. The Kītyāyana Srautasūtra (IV. 1. 23 ft) 204 mentions the view of Jātukarnya on pinda pitryajñol when all the three paternal ancestors of the performer are not deal and the Kalpataru on Srāddha (p. 240) remarks 'Jivatpit;kasya trayah pakšāņ'. 
+
+## 23 Devala
 
 23. Devala The name Devala as that of a sage frequently occurs in the Mahābhārata and is closely connected with Asita. Vide Sabhäparva 59. 9-11, Salya 50 and Säntiparva 230. In Subhā ( 72. 5) it is stated that Devala declared that a man has three lights viz. son, actions and correct knowledge. In the Gita also (in X. 13 ) Arjuna says all the sages, the Devasși Närada, Asita, Devala and Vyāsu speak of you as done in X. 12'. Sarkaricñrya in his bhâsya on Vedānti sutra 1. 4. 28 states that the Sărkhya system is nearer to Vedanta than other systems like the atomic theory, since it espouses the doctrine of the non-difference between cause 
 
@@ -5098,6 +5148,8 @@ The Mahābhārata ascribes the view to Devala tbat in man there are three jyoti8
 
 Aparārka and the Smộticandrikā cite verses from Devala on partition, inheritance, on woman's power over stridhana. These show that Devala, the jurist, flourished about the same time as the great jurists Bșhaspati and Kätyāyana. 
 
+## 24 Paithinasi
+
 24. Paithinasi Though not enumerated in Yājsavalkya, Paithinasi seems to have been a comparatively ancient sūtrakāra on Dharma. On Yāj. III. 262 Viśvarūpa quotes a sutra of Paithinasi on the prāyaścitta for kiling a cow. Dr. Jolly (R. und $. p. 12 ) following Dr. Caland ("Ahnencult &c.' pp. 99, 109) thinks that Paithinasi belenys to the Atharvaveda as the prose quotations on frăddha agree with the ritual of the Atharvans. The Mit. (on Yāj. I. 53 ) quotes a sutra of Paithinasi to the effect that di person should marry a girl who is beyond the third degree on the mother's side and beyond the fifth on the father's side. 271 On Yāj. III. 17 the Mit. quotes two sūtras relating to impurity on death.272 The Smộticandrikā, A parárka, Hara datta and other writers quote numerous sūtras of Paithinasi. The Smyticandrika has a prose quotation on the duties of women.273 In another place the Smộticandriká (II. p. 263 ) cites a sūtra on partition.274 Aparūrka (p. 112 ) quotes two verses of Paithinasi recommending the practice of sati to women of all castes except Brühmana women. Aparärka (p. 239 ) quotes a sūtra saying that the food of astrologers; 
 
 270 त्रीणि ज्योतींषि पुरुषे इति वै देवलोब्रवीत् । अपत्यं कर्म विद्या च यतः सृष्टाः 
@@ -5130,6 +5182,8 @@ History of Dharmasastra
 
 observed by a son being far away are ten from the day be hears of the death of his parents. P. in Vyavahāra-kalpataru p. 627 provides 'womenima are the presiding deities of the house, no rules of saucil (purification) or vrata or fasting are obliga tory for them; they reach the highest worlds by merely look ing after their husbands'. This is not to be understood literally but what it conveys is the great worth of pati susrisa.'; compare Manu V. 155 and Yaj. I. 87. Kalpa° on Vyava° p. 742 quotes a verse as occurring in both Sankha likhita and Paithinasi. Visvarupa ( on Yaj. III. 262 p. 147) provides (in prose) a prāyaścitta for à goghna ( one who causes a cow's death ). Paithioasi appears to have held the same view that is ascribed to Aupajanghani in Baud. Dh. S. II. 2. 39-41 (these verses being also quoted by Ap. Dh. II, 6. 13. 6 and also in Vas. 17. 9 without name in both ). Vide H. of Dh. Vol. II. p. 602 on 1417. Kalpataru on Vyava hāra p. 603 has : पैठीनसिः । तस्माद्रक्षेद्रायां सर्वतः । मा स्म सङ्करो भवत्विति । आह अप्रमत्ता रक्षत तन्तुमेनं मा वः क्षेत्रे परबीजान्यवाप्सुः । भायौं रक्षत कौमारी बिभ्यतः पररेतसः ।. One expects वाप्सुः instead of अवाप्सुः (as मा precedes). The editor quotes only विवादरत्नाकर on p. 603 probably to clinch his thesis that Candesvara merely borrows matters from Lakşmidhura and does not refer to Baud., Ap. or Vas., whom I had quoted years before in Vol. II (of H. of Dh. ). 
 
+## 25 Budha
+
 25. Budha This sūtrakāra is not mentioned by Yāj. nor by Parāśara. He is very rarely cited. Aparārka on Yāj. I. 4-5, Kalpataru on Brahmacāri pp. 24, 78, 160, on Gr. Kanda p. 262, Naiyata K. p. 211 (quoted in Vira-mitrodaya, Paribhāsa p. 16), Hemādri.378 Jimūta-vābana's Kāla viveka are probably the 
 
 478 खियो गृहदेवताः । तासां न शौचं न व्रतं नोपवासः । पतिशुश्रूषया गच्छान्त 
@@ -5153,6 +5207,8 @@ FOUNDED
 earliest writers and works to mention him. In the Deccani College Collection there are two mss. of a Budha-dharma Sastra in prose ( No. 507 of 1881-82 and No. 145 of 1895-1902, 2 folios ). The work is very brief 279 and speaks of upa mayana. marriage, eight forms of marriage, the samskāras from garbhadhāna to ujana yana, the five daily great yajñas, Sraddha, pikayajinas, haviryajnas, somayaga, the means of subsistence for a Brāhmana, the duties of Vaiśyas and Sūdras, the orders of forest hermits and sunnyāxins, removal of thorns by the king, administration of justice, king's duties. 
 
 The work does not produce the impression of being early. It is in the nature of a summary of larger works on dharma. All quotatious in Hemūdri cited from Budha are not found in the mss. 
+
+## 26 Brhaspati 
 
 26. Brhaspati 
 
@@ -5218,6 +5274,8 @@ There is a Srauta sūtra and a Grhya sūtra attributed to Bhāradvāja. The Ms. 
 
 su110 
 
+## 27 Bharadvāja and Bharadvaja 
+
 29. Bharadvāja and Bharadvaja 
 
 291 
@@ -5280,6 +5338,8 @@ f
 
 only for ten days, but could be annulled till the 9th year, if unfair. 393 It appears that the verses of Bharadvaja on vyavahāra are taken from a work other than the ancient work on politics. 
 
+## 28 Satatapa
+
 28. Satatapa Sãtātapa is enumerated among the expounders of dharma by Yāj. (I. 4-5) and by Parasura. Višvarūpa, Haradatta and Aparárka quote several proge passages of Sātātapa on prāyascitta. Visvarūpa (on Yāj. III. 236 ) tells us that Sātātapa -spoke of only eight, upapatakas and that without dealing with śrāddha as a principal topic he spoke of some of the subsidiary details of srāddha.294 The latter passage quoted from Sätātápa is a half verse. So Visvarūpa had a prose work of Sātītapa before him, mixed with verses, Haradatta on Gaut. ( Dh. S. 22. 18 ) quotes a prose passage of Sātāta pa about the penance for killing a cow. Visvarūpa on Yaj. III. 236 (part II. p. 93 ) states that Sătata pa mentioned in a prose passage only eight. Upapatakas .Sātātape tu. astum. vevopapātakāpyuktāni, athopa pătakānyagnyutsūdītyädini' eko. Visvarūpa on Yaj. III. 262 (part.2, p. 148) mentions a gutre of Sātätapa on präyuścittu. Maskarī on Gaut. 23. 35 quotes a prose passage from S. on prăyaścıttas unudaka-mutrapu. risayrabane svakakasparśane Sacelasuinam mahá vyåbrti. homuśca rajasvulnyamane cartildevann'. The Layhu-Satūta pa smrti (Anan. collection) contains several verses of Manu (e.g. verses 103, 105, 107 of it are respectively the girme as Mapu Ill, 237, III. 174, III. 233 and verses 45 and 58 refer to Sātätapa. Vfudba-Sätutupa is quoted several times in Kalpana taru e. g. ou pp. 98-99 of Brahma', on pp. 286, 405 of Grbus tha, 6 times on Sraddha. It is interesting to note that a verse of Satata pa quoted by the Mit. on Yáj. 1. 192 provides that a prāyasetta is not prescribed for men who bathe iri exidvink tbe water from a well or a dam dug or constructed by antyajus. The Mit. on Yáj. quotes several prose passages of 
 
 208 सन्धिश्व परिवृत्तिश्च विभागश्च समा यदि। आदशाहं निवर्तेत विषमे नववत्सरात् ।। till ensairait pp. 314. 320. 294 74 ÇAT: 16497&a ad JUFTTE - Porat gal taiata ang hasta hacer? Tufan 20 a. I. 46 . 
@@ -5319,6 +5379,8 @@ Hemādri mentions a Vrddha-Satâtapa along with several other smrtikāras (vide 
 The Mit. (on Yāj. III. 290 ) cites a Bộbat-Sâtātapa. 
 
 Hemādri (III, 1. 801) speaks of a bhâsyakāra of Vrddha Sātātape. 
+
+## 29 Sumantu
 
 29. Sumantu For a Dharmasūtra of Sumantu vide Madras Tri. Cat. of Sanskrit M88. (1919-22 ) pp. 5160-62. 
 
@@ -5389,6 +5451,8 @@ POOL
 FOUNDED 
 
 1917 
+
+## 30 The Smrtis
 
 30. The Smrtis 
 
@@ -5541,6 +5605,8 @@ In spite of all these drawbacks, an attempt will be made in the following pages 
 History of Dharmaśāstra 
 
 All these smộtis are not equal in authority. Most of them are obscure and are only rarely cited by ancient commenta tors. Exclusive of the dharmasutras hardly a dozen emptis have found commentators. If we are to judge of the authority of a smrti by the commentaries thereon, then the Manusmrti stands pre-eminent. Next to it is the Yājsavalkyasmrti. 
+
+## 31 The Manusmrti
 
 31. The Manusmrti So many editions of this work have been published in India since 1813 ( when the Manusmrti was first published at Calcutta ), that it is not possible to name them. In this work the Nirnayasāgara edition with the commentary of Kulluka has been used throughout. Another edition of Manu well known on this side of India is that of the late V. N. Mandlik, who published several commentaries such as those of Medha tithi, Govindaraja and others. The Manusmrti has been tran slated into English several times. The best known transla tion is that of Dr. Bühler in the S. B. E. series (vol. 25). Dr. Bühler also added an exhuustive and very scholarly intro duction to his translation and dealt with numerous problems connected with the Manusmrti. 
 
@@ -6311,6 +6377,8 @@ The above discussion shows that the extant Manusmrti was practically the same lo
 It may be noted that Sabaragvāmin on PMS. VI. 1. 12 quotes a verse as Smộti which is practically the same as extant Manu VIII. 116. Sabara has to be placed between 200 and 400 A. D. (nearer the former date); vide H. of Dh. Vol. V. p. 1197. Hence the extant Manusmrti cannot be placed later than 2nd century A. D. Vide the present author's paper on 'Gleanings from Sabara and the Tantravärtika' in JBBRAS (old series ) Vol. 26 ( 1924 ) pp. 83-98. 
 
 Višvarūpa ( on Yrij. I. 69 ), the Mitākṣarā, the Smộtica ndrikā, the Parāśarainadhaviya and other works quote dozens of verses from Vrddha--Manu on ühnika, vyavahāra and prāyuscittu. The Mitūksară (on Yāj. II. 135-6, III. 20 ), Aparārka p. 910 and other works cite a few verses from Brhan Manu. No independent works going under these names have yet been unearthed. Those works, if they ever existed independently, appear to have been later than our Manu. For example, our Manu is silent about the widow's right to inherit to her husband, but Vệddha-Manu recognises the right of a chaste widow to take the entire wealth of her husband (Mit. on Yäj. II. 136); similarly, Bșhan-Manu ( according to the Mit. ) seems to refer to Manu's view about the meaning of 'gamānodaka' (Manu 5. 60 ) and modifies it. It is not unlikely that those verses which were not recognised 28 Manu's by ancient commentators like Medhatithi and were yet found in the msg. of the Manusmrti were regarded as Vrddha-or Bphan-Manu. 
+
+## 32 The Two Epics
 
 32. The Two Epics The two great Epics of India, the Mahābhārata and the Rāmāyaṇa, contain ( particularly the first) numerous passa ges bearing on meny topics of Dharmaśästra and are relied upon as authorities in medieval and later works. The Mabu bhārata itself claims (in Adiparva, 2. 83) that VyDS composed the work as a great Dharmaśāstra, as Arthasastra ( treatise on politics and Government), Moksasistra and also 
 
@@ -7658,6 +7726,8 @@ the four verses quoted from the Rāmāyana in the Dānasāgara could be traced i
 
 It is impossible to deal with the numerous writings on the Rāmāyana. Jacobi's German work on the Rāmāyana has been translated into English by Dr. S. N. Ghoshal and published by driblets in several volumes of the Journal of Oriental Institute ( Baroda ). Numerous dates have been proposed for the Rāmāyana e. g. the Department of Letters, Vol. 19 ( Calcutta University ) puts down 433 A. D. as its date. The Rāma story occurs frequently in the Mahābhārata e. g. vide Sabhāparva 50. 39, Vanaparva chap. 148-152 (31 verses ), chap. 274-293 ( verses about 769 ); several Purāṇas such as Brahmao, chap. 123 and 154, Padmapurāna ( several times in Pătălakhanda and Uttarakhanda ), Nārada purāna, Bhāgavatapurāna (IX. 10-11 about 82 verses ), Agni purāna (chap. 5-12, verses 189 ). One writer in Preraņā ' monthly for October 1949 says that there are fourteen commentaries on the Rāmāyana. 
 
+## 33 The Puranas
+
 33. The Puranas The Yājňavalkyasmști provides that Purāna, NMAYA (Tarkaśāstra ), Mimāṁsā, Dharmaśāstra, the ( six, subsidiary lores of the Veda (angas ) and the Vedas (four )-these fourteen 
 
 FOUNDET 
@@ -8049,6 +8119,8 @@ Umāsaṁhitā 51): Varāha
 (upavāsa); Bhavisya Skanda I. (Kaumārikā 1. 17 ff, IV ( several hund- khanda ) 44 ( eight ordea red vratas ); Brahma 27 
 
 is described ). (upavāşa ); Brahmavai varta ( 4th khanda, pūr- | Yugadharinas- vide also vārdha 8 and 26 ); Garuda under Kulisvarūpa. 116-137, Lirga, pūrvārdha Garuda 223 ; Linga 39 ; 83-84 ; Nirada, pirvār- Matsya 141-143, 164 ; dha 17-22, 110-124 ; Närada, pūrvārdha 41; Matsya 54-80, 94-100; Skanda VI. 272 ; Vāyu I. Padma ( bhūmi 87, brah- 32 and 58. 
+
+## 34 The Yājnavalkyasmrti
 
 34. The Yājnavalkyasmrti This smrti has been published dozens of times. In the following the Nirnayasāgara edition edited by Sāstri Moghe ( 1892 A. D. ) has been used and the Trivandrum edition when speaking of Viśvarūpa. 
 
@@ -8712,6 +8784,8 @@ he commits. Eighteen whole verses out of 29 quoted on p. 9 are not found but mos
 
 Mr. Divanji's mentality is rather peculiar. On p. 113 of JBBRAS vol. 29, Mr. Divunji gives a list of eight items on quotations from and references to this work (i. e. to Yogayājñavalkya that be edits ) in other works. The first item (Sänkara-bhüşya on Sv. Up.) has been dealt with already. The third reference is to Sarvadarśanasangraha of Madhavă. cārya ( a work of the 14th century A. D.). That work, he says, contains four quotations of the work he edits. That work also quotes Brhad- Yoga - Yājñavalkya on p. 143 *Hirunyagarbho Yogasya &c. ( which is Br. Y. Y. XII.5). The 8th item ( and the last) on that page is above all, the author of the Yajnavalkya-Sinrti has in III. 110 referred to a 'Yoga sāstra promulgated by me,' which can be none other than this (and refers to his own Introduction on p. 8). This is an extraordinary argument. He was a high judicial officer in the days of the British rule. He has written profusely on this one work but with great regret the present author has to say he has not kept an open and judicial mind. He assum es as indisputable what has to be proved to the satisfaction of the scholarly world. The uther items that he puts forward on p. 113 above cited are worth little. 
 
+## 35 The Parāsara Smrti 
+
 35. The Parāsara Smrti 
 
 This work has been published several times, but the edi. tion of Jivananda (part II. pp. 1-52 ) and that in the Bombay Sanskrit Series with the voluminous gloss of the great Mādhava are the best known. In the following pages Jika nanda's edition has been used. 
@@ -8887,6 +8961,8 @@ calenta il TIHTATET p. 36. 603 On 13. III. 318 ( + that athal etc. ) que remarks
 FOUNDED 
 
 1917 
+
+## 36 The Nāradasmrti
 
 36. The Nāradasmrti 
 
@@ -9278,6 +9354,8 @@ SOUNDED
 
 History of Dharmaśāstra 
 
+## 37 Brhaspati
+
 37. Brhaspati Brbaspati as a sūtra writer on politics has been dealt with above ( section 26 ). In this section Brhaspati the jurist will be spoken of. The complete smrti of Bșhaspati on law has not yet been discovered. It will be, when discovered, a very precious monument of ancient India, exhibiting the high water mark of Indian acumen in strictly legal principles and definitions. Dr. Fübrer collected together 84 verses ascribed to Brhaspati in the legal treatises of Aparārka and others with German translation and notes ( Leipzig, 1879 ) and Dr. Jolly collected about 711 verses of Brhaspati on law and translated them in the Sacred Books of the East (vol. 33 ). 
 
 Yāj. (I. 4-5 ) enumerates Brhaspati among the writers on dharma, but he is probably referring to Brlaspati's work on politics. The com. on the Nitivákyrimpta (p. 7) quotes the first verse of Brhaspati's Nitišastra. 
@@ -9590,6 +9668,8 @@ Brhaspati and Kityayana ( and sometimes to three viz. Nar., Br., Kat., or Manu, 
 
 पक्षविदो विदुः ॥ विश्वरूप cites without name on Yaj. II. 6 ; व्यव. मा. p. 291, कल्पतरु (व्यवहार p. 8t ascribes to बृह. and कात्या.. अपराके p. 810, स्मृतिच. (व्य. p. 40) and परा. मा. III. p. 81 ascribe to बृहस्पति. (2) तपग्विनां तु कार्याणि विथैरेव कारयेत् । मायायोगविदां चैव न स्वयं कोपकारणात् ॥ व्य. मा. p. 281 ascribes to both बृहस्पति and कात्या०. and वीर p. 30 to बृह० ; व्यव. नि. p. 12 to बृह. It occurs in कौटिलीय I. 19. 32. (3) लेख्यदोषास्तु ये केचित्सा क्षणां चैव ये स्मृताः । वादकाले तु वक्तव्याः पश्चादुक्तान द्वषयेत् ॥ स्मृतिच. ( व्य. p. 83 ) ascribes to कात्या. ; अपरार्क p. 872, वीर. p. 184, व्य. म. p. 39 ( to बृह० ). (4) अर्थिना संनियुक्तो वा प्रत्यर्थिप्रहितोपि वा । यो यस्यार्थे विवदने तयोर्जय पराजयौ ॥ अपरार्क p. 639 ascribes to कात्या., व्य. मा. p. 287 to नारद and कात्या. (6) अनुपस्थापयन्मूलं क्रयं वाप्यशोधयन् । यथाभियोगं धनिने धनं दाप्यो दम च सः । मिता. on या. II. ( 170 ascribes to Manu ) ; स्मृतिच. ( व्यव. ) p. 216, वि. र. p. 108, व्य. म. p. 197, वीर• p. 381 ascribes to कात्या, (8) योगाधमनविक्रीतं योगदानप्रतिग्रहम् । यस्य वाप्युपधिं पश्येत्तत्सर्व विनि वर्तयेत् ।। अपरार्क p. 783 ascribes to कात्या ; स. वि. (सरस्वतीविलास p. 287 to नारद. This is मनु 8. 165. (7) आहूय साक्षिणः पृच्छेनियम्य शपथैभृशम् । समस्तान्विदिताचारान्विज्ञा तार्थान्पृथक् पृथक् ।। मिता. on या. II. 73 ascribes to कात्या० ; अपरार्क ascribes to नारद. (8) साहसस्तेयपारुष्यगोभिशापे तथा च ये। भूमौ च पादपे क्षिप्रमकालेपि बृहस्पतिः ॥ कल्पतरु (व्यव. p. 67) ascribes to both कात्या. and बृह., and परा. मा. III p. 17t ascribes to बृह. (9) सानिध्येपि पितुः पुत्रैऋणं देय विभावितम् । जात्यन्धपनितोन्मत्त क्षयश्वित्रा. दिरोगिणः ॥ कात्या. act. to अपरार्क. p. 650 वि. र. p. 51, वि. चि, p. 18, परा. मा. III. p. 263. In the Introduction to my edition of ENT reconstruction of Katyāyana I have (on pp. VIII-X) pointed out many verses that are common to Katyāyana, Brhaspati, Nārada. and Manu. 
 
+## 38 Katyayana
+
 496 
 
 History of Dharmaśāstra 
@@ -9896,6 +9976,8 @@ Kātyāyana himself is named in & verse that is cited from Kātyäyana by Par. M
 
 The number of Smộtis or Smrtikáras quoted or referred to by themselves or mentioned in commentaries and digeste is very large, particularly if one takes into account Sinștikäras or Smặtis with the words 'bphat''madhyama,' 'laghu' and 'vrddha' prefixed to many of them. The important versi fied Smrtis in the Sanskrit alphabetical order will now be briefly dealt with one after another. 
 
+## 39 Angiras
+
 39. Angiras Angiras is one of the ten primordial sages mentioned in Manusmrti 1.34-35). It is & very ancient oame even in the Rgverle. On Yāj. I. 50 Viśvarúpa quotes a verge of Angiras that what is done according to one's owo will without follow ing the dictates of Sästra is fruitless.578 On Yaj. III. 248 Visvarūpa says that the vrutie called Vajra wu8 prescribed by Angiras for Brähmunas guilty of deadly sins. Visvarūpa (on Yäj. III. 255 ) quotes two verses of Argiras on the prayaścitta for killine the wife of a brähinana who has kindled the sacred fires for killing wives of other brahmanas and ksatriyas and vaisyas. On Yåj. III. 266 he quotes two verses of 
 
 Y 
@@ -9952,11 +10034,17 @@ The Mitâksarā (on Yáj. 111. 277 ) and the Smştiratnávali of Vedācārya (I.
 
 ilistory of Dharmaśāstra 
 
+## 40 Rsyasrnga
+
 40. Rsyasrnga This is a writer who is frequently quoted on ācāra, āśauca, srāddha, and prāyaścittu by the Mit., Aparărka, Smịticand rikā and other works. A parārka (p. 724 ) quotes as Rsyas roga's a verse ascribed to Sarkha in the Mitāksarā ( on Yāj. II. 119 ) and other works, which states that when one copar cener recovers with his own efforts family property that was lost to the family, he gets a fourth share of it and the others become sharers in the rest.684 The Smrticandrikā (I. p. 32 ) quotes 'api vāsasi yajñopavitārthân kuryāt tadabhāve trivstā sütrena', which is in prose, 
 
 Rsyaśạnga is frequently quoted by Aparārka on the Prāyaścitta section of Yāj. (about 13 verses ) on Prāyaścitta. The Vy. N. of Varadaraja ( p. 26 ) ascribes the verse of Yāj. II. 32 ( Mattonmattārta &c) to Rsyaśşnga also. Aparārka (p. 724 ) quotes one verse of Rsya', on Vyavahāra viz. 'If one coparcener in a joint family recovers by his efforts pro perty lost to the fumily, he should be awarded one-fourth of it and the remaining portion should be distributed among the remaining coparceners according to their proper shares. This verse is ascribed to Saikha by the Smrticandrikā ( on p. 276 ). Kalpataru (on Vy. 622 ) quotes two verses on a wife's duties. 
 
+## 41 Karsnajini
+
 41. Karsnajini This writer is quoted by the Mit. (YĀj. III. 265 three verses ), Aparărka, Smộticandrikī and other works mostly op srāddha. A parārka (p. 138 ) quotes a verse from him which enumerates the seven sons of Bralmă, viz. Sanaka, Sanandana, Sanātana, Kapila, Asuri, Vodha (?) and Panca sikha. A parūrka (p. 424 ) quotes a verse of Kārsnājini which refers to the two signs of the Zodiac, Kanyā, and Vrścikā. 
+
+## 42 Caturvimsatimata
 
 42. Caturvimsatimata There are two Mgs. of this work in the Bhandarkar Institute, Poona (No. 244 of A. 1881-1882 and 111 of 1895-1902). It contains 525 verses. The work is so called because it embodies the essence of the teachings of 24 sages, Manu, Yājña valkya, Atri, Visņu, Vasistha, Vyāsa, Usanas, Apaskambe, 584 पूर्वनष्टा तु यो भूमिमेकश्येदुद्धरेत् क्रमात् । यथाशं तुं लभन्तेन्ये वाचशित 
 
@@ -10018,6 +10106,8 @@ INS
 
 Series ( Nos. 137 and 139 ). The commentary is a very learned one and refers to a host of writers. This commentary is in some mss. ascribed to Ramacandra ( vide I. O. Cat. No. 1554, p. 473). 
 
+## 43 Daksa
+
 43. Daksa 
 
 Dakşa is one of the writers on dharma enumerated by Yāj. Vigvarūpa quotes verses of Daksa several times, viz. on Yāj. 1. 17 (on clods of earth for purifying the body ), on Yāj. III. 30 (two verses on āśauca ), on Yāj. III. 66 ( about & parivrājaka ), on Yáj. III. 191 (about padmāsada ). The Mit. (on Yāj. I. 89) quotes a half verse of Daksa to the effect that a dvija should not remain unattached to an asrama (i. e. without a wife in the context ) even for a moment; on Yāj. III. 58 two verses about bhikṣus; on Yāj. III. 243 (one verse ). Aparārka cites numerous verses of Dakşa on ācāra, āśauca, srāddha and similar topics. In one case (p. 368 ) be attributes a prose passage to Dakşa about the gift of gold.500 Two of Daksa's verses most frequently quoted by writers on vyavahăra are those that lay down wbat nine things cannot be the subjects of gift.601 
@@ -10043,6 +10133,8 @@ Dakşasmrti contains the name of Daksa himself and shows that he was a thorough-
 This smrti is certainly a very old one. All the quota tions from Daksa cited by Visvarūpa occur in the printed Daksa (vide pp. 395, 396, 384, 397 which reads 'na pathyā sanād yogo'). Similarly all the quotations in the Mit. from Daksa are found in the Calcutta text. Aparārka contains over forty verses from the printed Dakşa, though there are a few verses cited by him as Dakşa’s which are not found therein. The Smộticandrikā quotes about ten verses of Dakša on woman which are all found in the 4th chap. of the Calcutta text. 
 
 In the Govt. Mos. library at the B. O. R. Institute Poona, there is a ms. of Daksa (No. 120 of 1895–1902), which contains 197 verses on the same topics as above, many of which are identical with the Calcutta text. The Bombay University has also a similar ms. Vide I. O. Cat. No. 1320 p. 385 for a similar ms. in 197 verses. 
+
+## 44 Pitāmaha
 
 44. Pitāmaha 
 
@@ -10098,6 +10190,8 @@ according to the śāstru; possession in order to be recognised by the courts as
 
 Pitāmaha is later than Bphaspati,603 as he cites the latter's view that a litigation between members of the same village, society, town, guild, caravan or army must be decided according to their peculiar usages. Therefore, Pitāmaha must be assigned to some date between the 4th and 7th century A. D. 
 
+## 45 Pulastya
+
 45. Pulastya Pulastya's name is among the ten primordial sages men tioned in the Manusmrti I. 34--35. 
 
 Pulastya is one of the expounders of dharma enumerated by Vrddha-Yājñavalkya. Višvarūpa quotes a verse from him on sārīraśauca.604 The Mit. (on Yāj. I. 261 ) cites & verse from Pulastya that a Brāhmaṇa should principally use asce tic's food (i. e. vegetable food ) in sråddha, that ksatriyas and vaisyas should use meat and būdras madhu.606 The Mit. (Yāj. III. 253 ) quotes two verses of Pulastya who enumerates eleven intoxicating drinks together with surā as the twelfth.806 Aparārka quotes several verses from Pulastya on saṁdhyā, Sraddha, asauca, duties of yatis, prayascitta. Aparārka quotes two verses from Pulastya propounding the view that a 
@@ -10123,6 +10217,8 @@ Aparārka (on p. 1136 ) quotes eight verses from Pulastya that provide various r
 The Dānaratnākara of Candeśvara cites a prose text from Pulastya on the gift of deer-skin.gog 
 
 The Pulastya-smrti must have been composed between 4th and 7th century A. D. 
+
+## 46 Paithīnasi
 
 46. Paithīnasi 
 
@@ -10182,6 +10278,8 @@ FOUNDED
 
 presiding deities of the bome; (strict) rules about purifica tion are pot demanded of them, nor the observance of vratas nor fasting; they reach the highest world if they properly look after their husbands. When an appointed daughter dies her husband does not succeed to her wealth; if she dies sonless, her wealth should be taken by her unmarried daughter or sister. On pp. 818 and 819, there are two prose passages, the first providing for the status of the children of a brāhmana, ksatriya or Vaisya woman born from a person of a lower varna and the second providing for the status of children born in unions (which are not bad on the ground of illicit inter course ). The Brahmacárikānda of the Kalpataru quotes 22 prose pasgages and seven verses from Paithīnasi. Kalpataru ( Moksakānda pp. 21-22 ) has a long sutra of Paithīnasi about the daily life of a forest hermit (vānaprastha ). Kalpataru (on Srāddha ) adduces prose passages of Paithīnasi fifteen times and only two verses. Kalpataru (on Suddhi) adduces from Paithinasi only prose passages ( 15 times ), some (as op pp. 105 and 140 ) being very long. Kalpataru (Naiyatakālika, quotes Paithīnasi 24 times; one prose passage ( about one pago in extent) deals with honouring a guest (on pp. 188–89) and there is another very long prose passage on rajasvalā occupy. ing one page and a half on pp. 352-3. 
 
+## 47 Pracetas
+
 47. Pracetas 
 
 Pracetas fiuds a place among the sages enumerated by Perāsara (though not in Yājñavalkya), in the list of 36 Smrti käras by Paithināsi in Smộticandrikă p. 1). In both Mit. and Aparārka there are passages in prose and verse ascribed to Pracetas on daily duties, srāddha, āśauca, prāyascitta. The Mit. (on Yāj. III. 27 ) quotes & verse from Pracetas saying that workmen, artisans, physicians, male and female slaves, kings, royal officers have not to observe periods of impurity 811 (on death). This verse is cited as a smrti by Medhātithi on Manu V. 60 without ascribing it to Pracetas. So Medhätithi looked upon Pracetas as equally authoritative with Manu, Višņu and others. 
@@ -10206,6 +10304,8 @@ The Mit. on Yāj. (III. 20, 263, 264 and 265 ), Haradatta on Gautama (22.18 ) an
 
 A few prose quotations from Pracetas are noted in the Smrticandrikā and by Haradatta (on Gautama 23. 1). 
 
+## 48 Prajapati
+
 48. Prajapati Prajāpati is cited as an authority by the Baudhāyana dharinasūtra (II. 4. 15 and II. 10. 71 ). Vasistha several times quotes Prājāpatya blokas (viz. III. 47, XIV. 16-19, 24-27, 30-32). It has been shown above that most of these Verses are found in the Manusmrti or have close correspon dence with verses of Manu. So it is not unlikely that both the writers of dharmasūtras mean Manu by Prajāpati. 
 
 In the Anandāśrama collection (p. 90-98 ) there is a smrti of Prajāpati in 198 verses on the various details of frāddha, such as the time, place, the persons authorised to perform, proper food, Brāhmanas to be invited etc. The pre vailing metre is Auustubh, but there are nine verses in the Indravajrā, Upajäti, Vasantatilakā (verse 137 ) and Sragdhară (verse 96 ). It speaks of Kalpaśāstra, smrtis, dharmaśāstra, purānas. It contains a verse referring to the Kanya and Vrścika ( scorpion ) signs of the Zodiac, which is almost the same as a verse of Kāršņājini. 
@@ -10223,6 +10323,8 @@ FOUNDED
 521 
 
 The Mit. (on Yāj. III. 25 and 260 ) quotes verses of Prajā pati on āśauca and prāyaścittu. Aparārka cites verses of Prajāpati on purification of various substances, on érāddha, witnesses, ordeals and āśauca. None of these is traced to the printed text of Prajāpati. A parārka (p. 952 ) gives a long prose text of Prajāpati on the four orders of parivrājakas, viz. kuticaka, bahudaka, hamsa, paramahamsa. Aparārka (p. 542) cites a verge of Laugākṣi which refers to the view of Prajā pati that the son of a putrika was to offer pindas to his mother by the gotra of his maternal grand-father.s13 Aparārka, Smrti. candrikā, Parāśara-Mădhaviya and other works quote several verses of Prajāpati on vyavahāra. Wituesses are of two kinds, krta and akrta.814 In this he seems to have followed Narada (rnadana, verse 149). Prajapati lays down the characteri stics of valid reply ( uttara ) of the defendant and defines 818 the four varieties of uttara. The Parāśara-Madhaviya cites several verses of Prajāpati on ordeals. Prajāpati recognised the right of the sonless widow to succeed to her husband's wealth018 and enjoined on her the duty of offering frāddha every month and year to her husband's manes and to honour his relatives.817 
+
+## 49 Marici
 
 49. Marici 
 
@@ -10253,6 +10355,8 @@ turpana, one of which speaks of Sunday.618 Marici disallows bathing in the river
 Prose passage of Marīci is 'Kanyānām prāk-cūļākaraḥāt sadyaḥ saucam | Prāgdānād-ekāhaḥ | Dattānām prāk-pariņa yanāt-tryaham | Aparārka p. 938. 
 
 It is to be noted that Aparārka ( p. 908 ) quotes a prose passage of Marici on āśauca. 
+
+## 50 Yama
 
 50. Yama 
 
@@ -10422,6 +10526,8 @@ History of Dharmaśāstra
 
 (lit. killed ) by mere ratiocination (tānyevātipranītāni pa hantavyāni hetubhiḥ ) we should read atipramāņādi for atipranītāni). Ou pp. 243, 270 there are prose passages. On p. 24, it quotes two Upajāti verses. In the Moksakānda Laksmīdhara quotes on pp. 101, 102 five verses of Yama wbich set out the eight prakřtis of the Sārkhya system and the 16 vikstis thereof, the 25th tattva viz. 'a vyakta' and adds Purusottama or Visnu as the 26th (pancavimsakam avyaktam sadviņśaḥ purusottamaḥ 1 Pañcavimšatitattva jño, Yāti Visnoh param padam || In Srāddhakānda Laksmi dhara quotes about 150 verses of Yama ( 17 on pp. 64-65 and 19 on pp. 82-83). Vyavahārakānda quotes about 47 verses of Yama. 
 
+## 51 Laugaksi
+
 51. Laugaksi 
 
 Laugākşi is mentioned among the 36 expounders of Dharmaśāstra set out by Paithīnasi (on p. 1 of Smộ. Ch.) and Angiras quoted on the same page includes Laugākşi among Upasmộtis. 
@@ -10440,9 +10546,13 @@ A
 
 Maskarin on Gaut. Dh. S. appears to quote Laugākşi as Lokāksi. On Gaut. 10. 42 ( about the finding of treasure trove) Lokāksi is quoted as "anubhūticibnāni musitvã gļhnataḥ pūrvasāhusam dandah tad-dravya dvigunam ca rājā haret'. Maskarin quotes verses of Lokāksi on Gaut. 14. 1, 15. 1; 22, 18 ( three verses on prāyaścittas for killing a person of pratiloma caste and others also). Kalpataru quotes Laugāksi frequently e. g. on Br. Kānda Laugākşi is quoted five times ( all prose); Kalpao (on Srāddha ) p. 98 defines ' Agredidhuşu and didhisū! 
 
+## 52 Visvāmitra
+
 52. Visvamitra Vievāmitra is one of the writers on dharma enumerated by Vrddha-Yājījavalkya as quoted by Visvarūpa. Aparárka, the Smộticandrikā, the Kālaviveka of Jimūtavāhana and other works quote verses of Viśvāmitra on almost all topics of dharma except vyavahāra, such as on the five deadly sins, on srāddhas, prāyaścitta etc. Viśvāmitra defines dharma as that which is esteemed by Aryas ( respectable people who know the Vedas. 640 Aparárka quotes 18 verses from Visvā. mitra on Prayascitta and the Sinrticandrikā also quotes several verses of his Kalpataru ( on Brahmacario), cites Yāj. I. 14 (Garbhāstame &c.) as occurring in Viśvāmitra also. Similarly Kalpataru (on Naiyatakāla p. 314 ) states that Yāj. I. 179 (prānātyaye &c. ) also occurs in Visvāmitra's Smộti. His verses on the mahăpătakas are frequently quoted.641 The Madras (Govt. ) Mss. cat. (p. 1985 No. 2717 ; notices a Smộti of Visvāmitra in verse in nine chapters. 
 
 RA 
+
+## 53 Vyāsa
 
 53. Vyāsa In Jivananda (part II, pp. 321-342 ) and in the Anandá srama collection of smộtis there is a smrti ascribed to Vyasa (pp. 357-371 ). The two texts are the same with a few variations. It is in four chapters and contains about 250 verses. Vyāsa is said to have declared the Smrti in Benares. 
 
@@ -10570,6 +10680,8 @@ the reply, proof and burden of proof, documents; the judge ment, eight different
 
 Some of the verses quoted as Vyāsa's occur elsewhere e. g. verse 11 ( of the above collection 'na si sabhā...viddham occurs in Nārada III. 18 and is quoted as Vyasa's in Aparārka ( p. 604). Similarly, the verse' na narmayuktam vacanam hinasti ( No. 111 in the list of Dr. Batakrishna Ghosh ) quoted by the Smộticandrikā ( Vy. p. 89 ) as Vyāsa's occurs in the Mahābhārata ( Adi. 82, 16 and Säntiparva 165. 30 ). Verse 129 (Adityacandrāvanilo which is the mantra to be employed in ordeals ) occurs in Adiparva 74. 30. No. 140 of the collection by Dr. Ghosh defines niska as equal to fourteen suvarnas.688 The Mit. on Yāj. I. 72 provides that a wife who drinks wine, who is guilty of adultery with the husband's pupil or guru, who kills her husband and particularly one who has inter course with a man of a degraded caste (such as a shoemaker) should be abandoned.864 So, whoever might have been the author of the Vyāsasmộti he incorporates some verses from the Mahābhārata therein. 
 
+## 54 Sat-trimsan-mata
+
 54. Sat-trimsan-mata The title literally means 'the doctrines of thirty-six (Smộtis )'. This appears to have been a work like the Catur vimśatimata. It has been stated above that Paithinasi enumerated thirtysix propounders of Dharma (vide Smrtican driká p. 1). Quotations from Șat-trimsan-mata cited in the 
 
 653 पलान्यष्टौ सुवर्णस्य सुवर्णाश्च चतुर्दश । एतनिष्कप्रमाणं तु व्यासेन परिकीर्तितम् ॥ 
@@ -10607,6 +10719,8 @@ The Mit. on Yij. III. 288 quotes Sat-trimsan-mata as prescribing that if one rec
 ___ The mit. (quotes about two dozen verses from Sat-trimsan mata on several verses of Yāj. viz. III 6, 17, 20, 250, 259, 263-64, 335-36 and a prose passsge on Yaj. III. 265 about 
 
 Krechra penance. 
+
+## 55 Samgraha or Smrtisamgraha
 
 55. Samgraha or Smrtisamgraha This work is frequently cited by the Mitākṣarā, Aparārka, the Smộticandrikā and other works on all topics of dharma, The quotations on vyavahāra are copious and are very im 
 
@@ -10700,6 +10814,8 @@ Parāśara, Manu, Yājňavalkya, Yama and Saunaka are cited by naine.673
 
 The Samgraha or Smộtisamgraha inust have contained a very large number of verses, since the Smộticandrikā alone quotes several hundred verses, from it on 'āhnika, Vyavahāra and Srāddha'. The Vyavahāra-nirưaya of Varadaraja states ion p. 324 ) that the view of Sangrahakāra is relied upon by Dhāreśvarabhatta ! 
 
+## 56 Samvarta
+
 56. Samvarta Saṁvarta occurs as a Smrtikāra in the list of Yājña valkya. He is cited on all topics of dharma by Visvarūpa, Medhātithi, the Mit., Haradatta, Aparirka, the Smộticandrikā and a host of other writers. Visvarūpa quotes either wholly or in part about twenty verses of Samvarta on evening sandhyā vandana, on the duties of a yuti and on the prāyaścittas for theft, adultery of various kinds, deadly sius. Medhātithi quotes verses of Surivarta on Manu V. 88 and XI. 116. The Mit. quotes him on prayascitta and aśauca ( Yāj. III. 6. 17 19 etc. ). Apararka had a large work before him and quotes about 200 verses almost all on īcīra and priyuscitta. 
 
 A few of the views of Samvartu on topics of vyavahāra may be noted here. According to him oral testimony when in opposition to writing was to be discarded. 674 This is in striking agreement with section 92 of the Indian Evidence Act. He says that if houses and fields are being enjoyed ( by one person us against another ) when the king is there (i. e. when the central government is strong and there is no 
@@ -10750,6 +10866,8 @@ The Mit. quotes a Bphat-Saṁvarta (on Yāj. III. 265 288 ).
 
 A Svalpa-Sarvarta is quoted in Harinātha's Smrtisāra. 
 
+## 57 Harīta
+
 57. Harīta The verse quotations from Hārīta on topics of vyavahāra deserve some treatment. He defines vyavahāra as that where by the recovery of one's own wealth and the avoidance of (doing ) the duties peculiar to another (caste or class ) are effected in due course of law.878 He further says that that judicial proceeding is proper which is based on the dictates of dharmaśāstra and arthasāstra, which is in conformity with the usages of respectable people and which is free from fraud.978 Hārita calls upon the king to know the sāstras, the 
 
 NST 
@@ -10796,6 +10914,8 @@ According to him sureties are of five kinds,686 abhaya (for keeping the peace), 
 
 It appears from the above that Harita the jurist must have flourished nearly at the same time as Brhasrati and Kātyāyana, i. e. between 400 and 700 A. D. 
 
+## 58 Commentaries and Nibandhas
+
 58. Commentaries and Nibandhas ( digests ) 
 
 The literature on Dharmaśāstra falls into three well marked but somewhat over-lapping periods. The first period is that of the ancient dharmasūtras and of the Manusmrti. It is a period dating from at least the 6th century B. C. to the beginnings of the Christian era. Next comes the period when most of the versified smrtis were composed and it ranges from the first centuries of the Christian era to about 800 A. D. The third period is that of the commentators and the writers of digests. This covers over a thousand years from about the 7th century to 1800 A. D. The first part of this last period was the golden era of famous commentators. Commentaries on smrti works continued to be written almost to the end of this period, e. g. Nandapandita wrote the commentary called Vaijayanti on the Visnudharmasūtra in the 17th century. But the general tendency from the 12th century onwards was 
@@ -10835,6 +10955,8 @@ FOUNDED
 History of Dharmaśāstra 
 
 to write works not professing to be commentaries on a parti cular smộti, but works that were in the nature of digests containing a synthesis of all the dicta of smrti writers on topics of dharma. Examples of this class of works are the Kalpataru, the Smộticandrikā, the Caturvargacintāmaņi, the Ratnākaras of Candeśvara. Even when in the earlier part of this period writers professed to compose only commentaries on particular works, they adopted the style of digests trying to introduce order out of a chaotic mass of Smrti dicta and explaining away apparent contradictions. For example, Visvarūpa's commentary (in the ācāra and prāyaścitta sec tions ), the Mitāksarā and Aparārka's work, though professing to be commentaries on Yājšavalkya, are really in the nature of digests. In fact there is no hard and fast line of demarca tion between a tikā and a nibandha ( digest). Vijñānesvara is described by the Dvaitanirnaya of Sankara bhatta as the most eminent of all writers of ribandha8.. Therefore, though it is usual to speak of the third period as one of commenta tors and nibandhakāras, there is no necessity in this work to observe any sharp line of distinction between the two. In the following pages a few prominent and typical commentators and nibandhakāras who have written on all or most of the branches of dharmaśāstra and whose works have attained classical rank will be dealt with in chronological order as far as that can be done with any accuracy. 
+
+## 59 Asahāya
 
 59. Asahāya 
 
@@ -10980,6 +11102,8 @@ FOUNDED
 
 The Vivādaratnākara 03 (p. 578 ) quotes the Prakāśa as refer ring to the views of Asahāya and Medhātithi on Manu IX. 198 that the special rule of Manu applies to all the stridhana belonging to a Ksatriya woman who has a brāhmani co-wife. The Vivādaratnākara704 quotes a verse of Nārada about māsa and a verse of the blāsyakāra thereon. It probably refers to Asahāya's bhāsya. 
 
+## 60 Bhartryajna
+
 | áo. Bharteyajĩa This seems to have been a very ancient commentator. Medhatithiros in his bhāsya on Manu 8. 3 says 'other explana tions have been well brought out by Bhartļyajña and they should be understood from his work'. Trikānda-mandana (who flourished before 1100 A. D.) in his Āpastambasūtra dhvanitārtha-kāriki708 (I. 41) refers to the views of Bhartr yajña that one who had committed to memory the text of the Veda had the privilege ( the adhikāra ) of consecrating the sacred fires, though he may be innocent of the meaning of the Vedic texts. From Ananta's bhâsya it appears that Bhartryajña composed a bhāsya on the KĀtyāyanaśrautasūtra which had been lost (autsanna) in the former's day. From Gadūdhara's comments on the Paraskaragrhyasūtra it appears that Bhartryajña commented on Päraskara,707 The Grhastha ratnākara of Candeśvara quotes Bhartsyajña’s explanation of 
 
 703 पित्रा दत्तमिति स्त्रीधनमात्रोपलक्षणमित्यसहायमेधातिथिरिति (थी इति?) 
@@ -11017,6 +11141,8 @@ p. 12. 710 873 a fullar ureterala HTAT: 1 TEM PAT folio 133,61. Višvarūpa
 553 
 
 Since Bhartryajña is quoted by Medhătithi who also men tions Asahāya but not Viśvarūpa, it follows that Bhartryajia must have flourished before 800 A. 1), and was probably & contemporary of or slightly later than Asahāya. 
+
+## 61 Viśvarupa
 
 61. Viśvarupa The commentary of Viśvarūpia called Bālakrīdā on the Yājsavalkya-smrti has been recently published in two parts by M. M. T. Ganapati Sāstri in the Trivandrum Sanskrit Series. The Mit. states in the introductory verses that the dicta of Yij. were expanded by the voluminous or ample (vikata ) explanations of Visvarüsra. In commenting on Yāj. 1. 81 the Mit. tells us that Visvarūjia looked upon the words of Yāj. I. 79 ( tasmin yugmāsu saṁviset ) as a niyama. In Visvarūpa's commentary on Yāj. I. 80 (evam gacchan &c. ) we do find that the verse of Yāj. and similar passages of Manu (3. 45 ), Vasistha and Gautama ( 5. 1 ) are understood to contain a niyam and not a prescinkhyu.?!! On Yāj. III. 24 the Mit, inforins us that Visvarūpa, Medhatithi and Dhāre svara looked upon certain texts of Rsyasriiga on āściucu as in conflict with well-known sinitis and discarded them. Mr. S. Sitaram Sústri published (in 1900 at Madras ) the text and translation of Viśvarūpia's comment ou inheritance and Mr. Setlur also published the wavahürco section. In the following pages the Trivandrum edition is relied on. 
 
@@ -11316,6 +11442,8 @@ remarkably with the words of the Mit. on Yāj. I. 53. The Varsakriyakaumudi (pp.
 
 . 
 
+## 62 Bhāruci
+
 62. Bhāruci The Mit. on Yij. (I. 81) says that Bhiruci like Visvaripa held the view that the rulertau bhüryam gacchet' was a niyanma and not a paristkrinkhayti. On Yij. II 124 the Mit. says that the explanation of' the fourth share' to be given to un married sisters oflered by Asahiya and Medhitithi was the 
 
 732 अत एवोक्तं श्राद्धकलिकायां-मासिकानि सपिण्डं च अमावास्या तथाब्दिकम् । 
@@ -11442,6 +11570,8 @@ Grafy CET AT TIET JETA waf hf 31180 11 ... 3747 Branca पठ्यन्त ए
 
 whole of Bharuci's available text is printed and carefully studied. Vide remarks under Sarasvativilāsa of Prataparudra deva for various passages of Bharuci referred to and Manu, particularly VII. 13. 
 
+## 63 Srikara
+
 63. Srikara The Mit. on Yāj. II. 135 alludes to the view of Srikara and others that the widow succeeded is heir to her deceased husband's estate if it was small.743 The Smytisära744 of Harinātha attributes the same view to Srikara and disappro ves of it. On Yāj. II. 169 the Mit.746 cites the view of Srikara about that topic and disapproves of it. Visvarūpa also gives two explanations of that verse of Yāj., the first of which agrees with that of the Mit, and the second is akin to Srikara's. 
 
 The works of Jimütavāhana (viz. the Dayabhāga and the Vyavahāramātřkā ), the Smrticandrikā and the Sarasvati vilāsa contain very interesting notices of Srikara's views. Many of them were brought together by ne in JBBRAS for 1925, pp. 213-215. Srikara like Visvarūpa held the view that 'duhitarah in Yüj. refers to the putriku, he allowed the parents of a chililless person to succeed together at the same time. The Diyabhāga very severely criticizes the views of Srikara on the succession to re-united members, on vidyā dhana and on Yaj. II. 24 ( about enjoyment for 20 years ). 148 Most of the views attributed to Srikara were also entertained by Visvarūpa ur are more antiquated than Viśvarūpa's. 
@@ -11493,6 +11623,8 @@ As Srikara is quoted by the Mit., he is certainly earlier than 1050 A. I). As hi
 This Srikara must be distinguished from another Srikara, the father of Srinātha. 
 
 1 
+
+## 64 Medhatithi
 
 64. Medhatithi Medhatithi is the author of an extensive and erudite commentary ( bhusyu ) on the Manusmrti. It is the oldest extant commentary on that smrti. The bhâsya of Medhătithi was first published about forty years ago by Rao Saheb V. N. Mandlik in Bombay and recently Mr. J. R. Gharpure of Bombay brought out an edition of Medhātithi which closely follows Mandlik's edition. A critical edition of the bhāsya based upon all the available Msg. is a great clesideratum. A new edition in two volumes based on several mss. edited by M. M. Dr. Ganganath Jha was published in the G. O. I. Series in 1932 and 1939. In this edition also ten verses in the 3rd adhyāya are wanting and in adhyāya nine there 
 


### PR DESCRIPTION
I have inserted titles for all 64 titles in the PDF.

Few points to note:

- The PDF doesn't have p.479 (between PDF p.487 and p.488). So, the OCRed text also doesn't have that page.
- The title 'Other Sutra Works on Dharma' in p.260 (PDF p.269) is not numbered. So, I have not marked that title.
- Some titles have diacritics in the PDF. But they are incorrect/missing in the OCRed text. I have retained the title as it is in the OCRed text.