### PR TITLE
sgk - fix the markup in v1p102 -- sources of dharma

### DIFF
--- a/kANe/v1p1/02_sources_of_dharma.md
+++ b/kANe/v1p1/02_sources_of_dharma.md
@@ -3,118 +3,73 @@ title = "02 Sources of Dharma"
 
 +++
 
-2. Sources of Dharma The Gautamadharmasūtra?? says 'the Veda is the source of dharma and the tradition and practice of those that know it (the Veda ).' So Āpastamba18 says the authority (for the dharmas ) is the consensus of those that know dharma and the Vedas.' Vide also the Vasisthadharma-sūtra 19 (I. 4-6). The Manusmṛti20 lays down five different sources of dhurmu “the whole Veda is (the foremost) source of dharma and (next) the tradition and the practice of those that know it (the Veda); and further the usages of virtuous men and self-satisfaction.' Yājña valkya21 declares the sources in a similar strain the Veda, traditional lore, the usages of good men, what is agreeable to one's self and desire born of due deliberation-this is traditionally recognised as the source of dharma.' These passages make it clear that the principal sources of dharma were conceived to be the Vedas, the Smrtis, and customs. The Vedas do not contain 
+2. Sources of Dharma
 
-(Continued from last page) and Sramaṇas, obeisance to mother, father and old persons'. In the beginning of this aedict Asoke mentions that for centuries before him 
+The Gautamadharmasūtra[^17] says 'the Veda is the source of _dharma_ and the tradition and practice of those that know it (the Veda).' So Āpastamba[^18] says 'the authority (for the _dharmas_) is the consensus of those that know _dharma_ and the Vedas.' Vide also the Vasiṣṭhadharmasūtra[^19] (I. 4-6). The Manusmṛti[^20] lays down five different sources of _dharma_ 'the whole Veda is (the foremost) source of dharma and (next) the tradition and the practice of those that know it (the Veda); and further the usages of virtuous men and self-satisfaction.' Yājñavalkya[^21] declares the sources in a similar strain 'the Veda, traditional lore, the usages of good men, what is agreeable to one's self and desire born of due deliberation--this is traditionally recognised as the source of dharma.' These passages make it clear that the principal sources of _dharma_ were conceived to be the Vedas, the Smṛtis, and customs. The Vedas do not contain positive precepts (_vidhis_) on matters of _dharma_ in a connected form; but they contain incidental references to various topics that fall under the domain of dharmaśāstra as conceived in later times. Such information to be gathered from the Vedic Literature is not quite as meagre as is commonly supposed. In another place[^22] I have brought together about fifty Vedic passages that shed a flood of light on marriage, the forms of marriage, the different kinds of sons, adoption of a son, partition, inheritance, _śrāddha_, _strīdhana_. To take only a few examples. That brotherless maidens found it difficult to secure husbands is made clear by several Vedic passages. 'Like (a woman) growing old in her parents' house, I pray to thee as Bhaga from the seat common to all[^23]'. Vide also Ṛgveda I. 124. 7, IV. 5. 5 and Atharvaveda I. 17. 1 and Nirukta III. 4-5. These passages constitute the basis of the rules of the Dharmasūtras and the Yājñavalkyasmṛti against marrying a brotherless maiden[^24]. This bar against marrying a brotherless maiden seems to have been due to the fear that such a girl might be an appointed daughter (_putrikā_) and that a son born of such a girl would be affiliated to his mother's father. This custom of _putrikā_ is an ancient one and is alluded to in the Ṛgveda, according to Yāska[^25]. Ṛgveda X. 85 is a very interesting hymn as regards marriage ; verses from it are used even to this day in the marriage ritual[^26]. It shows that in the remote Vedic age the marriage rite resembled in essence the Brāhma form as described in the Dharmasūtras and Manu.[^27] But the purchase of a bride (i.e. what is called Āsura marriage in later literature) was not unknown in the Vedic age. A passage of the Maitrāyaṇīyasaṁhitā ((I. 10. 11) is referred to in the Vasiṣṭhadharmasūtra[^28] in this connection, viz. 'she who being purchased by the husband'. The Gāndharva form is hinted at in the words[^29] 'when a bride is fine looking and well adorned, she seeks by herself her friend among men'. The importance of the _aurasa_ son was felt even in the remote Vedic ages. 'Another (person) born of another's loins, though very pleasing, should not be taken, should not be even thought of (as to be taken in adoption[^30])'. The Taittirīya-saṁhitā (VI. 3.10.5) propounds the well-known theory of the three debts[^31]. The story of Śunaḥśepa in the Aitareya-brāhmaṇa (VII. 3) suggests that a son could be adopted even when there was an _aurasa_ son. The Taittirīya-saṁhitā (VII. 1. 8. 1) tells the story of Atri who gave an only son in adoption to Aurva. The Kṣetraja son of the Dharmasūtras is often referred to in the earliest Vedic literature. 'What (sacrificer) invites you (Aśvins) in his house to a bed as a widow does a brother-in-law or a young damsel her lover'[^32]. The Taittirīya-saṁhitā makes it clear that a father could distribute his wealth among his sons during his own life-time, 'Manu divided his property among his sons' &c.[^33] Another passage of the same _Saṁhitā_ seems to suggest that the eldest son took the whole of the father's wealth 'therefore people establish their eldest son with wealth'[^34]. Even in the Vedic ages the son excluded the daughter from inheritance 'a son born of the body does not give the paternal wealth to (his) sister'[^35]. A passage of the Taittirīya-saṁhitā is relied upon by ancient and modern writers on _dharmaśāstra_ for the exclusion of women in general from inheritance: 'therefore women being destitute of strength take no portion and speak more weakly than even a low person'[^36]. The Ṛgveda eulogises the stage of studenthood and the Śatapathabrāhmaṇa speaks of the duties of the Brahmacārin such as not partaking of wine and offering every evening a _samidh_ to fire[^37]. The Taittirīya-saṁhitā (VI. 2. 8.5) relates[^38] how Indra consigned _Yatis_ to wolves (or dogs) and how Prajāpati prescribed a Prāyaścitta for him. The Śatapathabrāhmaṇa speaks of the king and the learned brāhmaṇa as the upholders of the sacred ordinances.[^39] The Taittirīyasaṁhitā says 'therefore the Sūdra is not fit for sacrifice[^40].' The Aitareya Brāhmaṇa tells us that when a king or other worthy guest comes, people offer a bull or a cow[^41]. The Śatapatha-brāhmaṇa speaks of Vedic study as _yajña_ and the Taittirīya-āraṇyaka[^42] enumerates the five _yajñas_, which are a prominent feature of the Manusmṛti. The Ṛgveda eulogises the gifts of a cow, horses, gold and clothes[^43]. Another passage of the Ṛgveda[^44] (thou art like a _prapā_ in a desert) is relied upon by Śabara on Jaimini (I. 3. 2) and by Viśvarūpa on Yājñavalkya as ordaining the maintenance of _prapās_ (places where water is distributed to travellers). The Ṛgveda condemns the selfish man who only caters for himself[^45].
 
-people indulged. in injuring or killing living beings. From the Mababbasya on Vārtika 2 on Paṇini 11. 4. 12 it appears that in Patanjali's time there was permanent or aatural opposition or antipathy between Sramanas and brāhmaṇas; 'yeśām ca virodha ityasyāvākāśaḥ śramanabrābmanam'; 'Yeṣim ca virodhaḥ śāśvatikah' is Pāṇini II, 4, 9, Vide Rhys Davids “ Buddhist India" (ed. of 1950) pp. 192-194 for Asoka's Dhamma to be gathered from his Rock Edicts I, III, VII, IX, XII, and Pillar Edicts 2 and 3. There is not a word 
+The foregoing brief discussion will make it clear that the later rules contained in the _dharmsūtras_ and other works on _dharmaśāstra_ had their roots deep down in the most ancient Vedic tradition and that the authors of the _dharmasūtras_ were quite justified in looking up to the Vedas as a source of _dharma_.
+But, as said above, the Vedas do not profess to be formal treatises on _dharma_; they contain only disconnected statements on the various aspects of _dharma_; we have to turn to the smṛtis for a formal and connected treatment of the topics of the _dharmaśāstra_. Vide Prof. S. C. Bannerjee's 'Dharmasūtras, a Study' pp. 514-533 for Vedic passages cited in major Dharmasūtras and pp. 533-539 for references to them by name or by initial word or words.
 
-about God, the soul, about Buddha in these edicts. 17 Et Trialgsi a Fridaltaisit. . 7. 1. 1-2. 18 TÅSAAT: SAN CT29 1 3719. 4. &. I. 1. 1.2. 19 sidfaraiangat usta 1 gota FTZIAR: 981094 fare: GAETHIHII 20 वेदोखिलो धर्ममूलं स्मृतिशीले च तद्विदाम् । आचारश्चैव साधूनामात्मनस्तुष्टिरेवल 
+Before proceeding further a few preliminary remarks must be made. Ancient Sanskrit writers and modern historians of Sanskrit Literature divide ancient Sanskrit works into three groups, viz. the Vedic Samhitās (Ṛgveda, Yajurveda, Sāmaveda and Atharvaveda ), the Brāhmaṇas (including the early Upaniṣads like the Bṛhadāraṇyaka) and Sūtras. The first two groups together constitute Veda or Śruti (as Sabara says on P. M. S. II. 1. 33 'Mantrāś-ca Brāhmaṇam ca Vedaḥ'). Sūtras are not Veda, but many of thom are connected with the Veda and contain numerous mantras. Kalpa is one of the six auxiliary lores (aṅgas) of the Veda and this group is generally later in time than the Brāhmaṇas, though some sūtra works appear to have been composed even in the times of the Tai. Ār. II. 10 and of the Bṛhadāraṇyakopaniṣad (II.4.10 and IV.5.11). A distinction is drawn between Kalpa and Kalpasūtra by the Tantravārtika.[^45a] The word Kalpa (or rather Kalpasūtra) is used in two senses, one comprehensive including the aphoristic works on Vedic ritual, on the domestic ceremonies and also on law, government and administration of justice; the other sense covers only those aphoristic works that deal with Vedic sacrifices and matters related thereto. If the first sense is taken then Kalpasūtras are classified into three classes, viz. Śrautasūtras that deal with solemn Vedic sacrifices, mentioned or discussed in the Vedas and Brāhmaṇas; (2) Gṛhyasūtras that deal with domestic ceremonies such as Upanayana, marriage and with daily and periodical rites and employ mantras for them mostly from one Śākhā of the Veda; (3) Dharmasūtras (also depending on the Vedas as the highest authority) that treat of some of the topics dealt with in the Gṛhyasūtras but add provisions on matters concerning economic life, politics, government, civil and criminal law. A complete Kalpa in the first sense should cover all the three divisions. It is highly doubtful whether each Veda Śākhā had originally a complete set of the three kinds of works covered under the word Kalpa. This will be briefly dealt with a little below.
 
-Herzia II, 6. 21 श्रुतिः स्मृतिः सदाचारः स्वस्य च प्रियमात्मनः । सम्यक्सङ्कल्पजः कामो धर्मलमि 
+Recently (1959) Dr. Ram Gopal has brought out a large work on 'India of Vedic Kalpasūtras' containing over five hundred closely printed pages. The title of the work is rather misleading. It does not deal with the Śrautasūtras beyond very briefly stating what they contain and distinguishing their contents from those of the Gṛhya and Dharmasūtras. His work is concerned only with the details gathered from the Gṛhya and Dharmasūtras and he has nothing to say about the development of the several topics dealt with in these two classes during the long period of at least 2000 years after the sūtra period (which he places between 800 - 500 B. C. on p. 89). His work should have been entitled "Indian Life as depicted in Gṛhya and Dharmasūtras". As far as it goes it is a tolerable thesis, though rather prolix, dogmatic and over-disputatious. Having confined himself to the Gṛhya and Dharmasūtras, it should have been his business to discuss all points concerning at least the principal Gṛhya and Dharmasūtras. But he leaves important matters concerning several sūtras untouched. For example, on p. 54 he observes 'many sūtras in the Gaut. Dh. S. appear to be of doubtful authenticity and it is an important _task for future researchers_ to determine precisely the spurious sūtras interpolated in the original Dharmasūtra'. One feels that he should himself have tackled that task at least about some representative Gṛhya sūtras and the Gautama-dharma-sūtra (which he places on p. 84 among the oldest class of Śrauta, Gṛhya and Dharmasūtras and when on p. 82 he holds that Gautama is undoubtedly the oldest writer on Smārta Dharma) by a thorough examination of chapters and passages in them and should have pointed out the criteria why certain sūtras are held to be spurious and so forth. He need not have included in the thesis the description of the flora and fauna &c. (pp. 103-109) or if he wanted to include these subjects he should have devoted more space. Nor was there any need for him to discuss (as he does on pp. 100-103 ) the varying limits of Āryavarta, since that subject had been dealt with at length by me in H. of Dh. Vol. II pp. 11-16. He hardly adds anything substantial to what I stated on that topic twenty two years ago. He could have referred to Vol. II of H. Dh, pp. 11-16 and added bits of information that did not occur therein.
 
-Fan 11 719. 1. 7. 
+[^17]: वेदो धर्ममूलम्। तद्व्द्वां च स्मृतिशीले। गौ. ध. सू. I. 1-2
 
-FOUNDED 
+[^18]: धर्मज्ञसमयः प्रमाणं वेदाश्च। आप. ध. सू. I.1.1.2.
 
-1917 
+[^19]: श्रुतिस्मृतिविहितो धर्मः। तद लाभे शिष्टाचारः प्रमाणम्। शिषटः पुनरकामात्मा।
 
-2. Sources of Dharnu. 
+[^20]: वेदोखिलो धर्ममूलं स्मृतिशीले च तद्विदाम्। आचारश्चैव साधूनामात्मनस्तुषटिरेव च॥ मनुस्मृति II.6.
 
-positive precepts (vidhis) on matters of dharma in a connected form; but they contain incidental references to various topics that fall under the domain of dharmaśāstra as conceived in later times. Such information to be gathered from the Vedic Litera ture is not quite as meagre as is commonly supposed. In another place22 I have brjught together about fifty Vedic passages that shed a flood of light on marriage, the forms of marriage, the different kinds of sons, adoption of a son, partition, inheritance, śrūddha, strīdhana. To take only a few examples. That brotherless maidens found it difficult to secure husbands is made clear by several Vedic passages. “Like ( a woman) growing old in her parents' house, I pray to thee as Bhaga from the seat common to al123. Vide also Rgveda I. 124, 7, IV. 5. 5 and Atharvaveda I. 17. 1 and Nirukta III. 4-5. These passages constitute the basis of the rules of the Dharmasūtras and the Yājñavalkya smrti against marrying a brotherless maiden24. This bar against marrying a brotherless maiden seems to have been due to the fear that such a girl might be an appointed daughter (putrikū) and that a son born of such a girl would be affiliated to his mother's father. This custom of putrikū is an ancient one and is alluded to in the Rgveda, according to Yāska25. Rgveda X. 85 is a very interesting hymn as regards marriage ; verses from it are used oven to this day in the marriage ritual.26 It shows that in the remote Vedic age the marriage rite resem bled in essence the Brāhma form as described in the Dharma sūtras and Manu.27 But the purchase of a bride (i. e. what is called Asura marriage in later literature ) was not unknown in the Vedic age. A passage of the Maitrāyaniyasainhitā ((I. 10. 11) is referred to in the Vasisthadharmasūtra28 in this con nection, viz. "she who being purchased by the husband'. The 
+[^21]: श्रुतिः स्मृतिः सदाचारः स्वस्य च प्रियमात्मनः। सम्यक्सङकल्पजः कामो धर्ममूलमिदं स्मृतम्॥ याज्ञ. I.7.
 
-CINE 
+[^22]: Vide JBBRAS. Vol. XXVI (1922), pp. 57-82.
 
-22 Vide JBBRAS. Vol. XXVI (1922), pp. 57-82. 23 mala falt: wat aalt ziararet ad Heqitia vital II. 17. 7. 24 spelfort 9174a1a2aT47571413. I. 53. Vide also Hq III. 11. 25 Vide Rgveda III. 31. 1 and Nirukta III. 4. 20 C. . the verse Teoh ā AH11CT (FEE X. 85. 36). Vide 3719. Z. . 
+[^23]: अ॒मा॒जूरि॑व पि॒त्रोः सचा॑ स॒ती स॑मा॒नादा सद॑स॒स्त्वामि॑ये॒ भग॑म्। ॠग्वेद​ II.17.7.
 
-IV. 4 27 til. 7. E. IV.4; al. 87. 7. I. 11. 2: 3177. 47. 4. II. 5. 11. 176 
+[^24]: अरोगिनणीम् भ्रातृमतीमसामानार्षगोत्रजाम्। याज्ञ. I.53. Vide also मनु III.11.
 
-III, 27. 28 FEHAVE 1. 36-37: note 3779. 7. 8. II. 6. 13. 11 where the word 
+[^25]: Vide Ṛgveda III.31.1. and Nirukta III.4.
 
-'purchaee' is tried to be explained away and also q. ff. . VI115 
+[^26]: e.g. the verse गृ॒भ्णामि॑ ते सौभग॒त्वाय॒ (ॠग्वेद​ X.85.36.). Vide आप​. गृ. सू. IV.4.
 
-FYRI AMATTA.' 
+[^27]: गौ. ध​. सू. IV.4; बौ. ध​. सू. I.11.2 : आप. ध​. सू. II.5.11.17 : मनु III.27.
 
-POG: 
+[^28]: वसिष्ठधर्मसूत्र​ I. 36-37 : note आप​. ध​. सू. II.6.13. where the word 'purchase' is tried to be explained away and also पू. मी. सू. VI.1.15. क्रयस्य धर्ममात्रत्वम्'
 
-History of Dharmaśāstrui 
+[^29]: भ॒द्रा व॒धूर्भ॑वति॒ यत्सु॒पेशा॑: स्व॒यं सा मि॒त्रं व॑नुते॒ जने॑ चित्। ॠग्वेद​ X.27.12.
 
-CY 
+[^30]: न॒हि ग्रभा॒यार॑णः सु॒शेवो॒ऽन्योद॑र्यो॒ मन॑सा॒ मन्त॒वा उ॑। ॠग्वेद​ VII.4.8.
 
-YOK 
+[^31]: जायमनो वै ब्राह्मणस्त्रिभिरॄणवा जायते ब्रह्मचर्येण ॠषिभ्यो यज्ञेन देवेभ्यः प्रजया पितृभ्यः।
 
-Gāndharva form is hinted at in the words29 .when a bride is fine looking and well adorned, she seeks by herself her friend among men'. The iniportance of the aurasa son was felteven in the remote Vedic ages. “Another ( person ) born of another's loins, though very pleasing, should not be taken, should not be even thought of (as to be taken in adoption30). The Taittiriya-samhita (VI. 3.10.5) propounds the well-known theory of the three debts31. The story of Sunaḥsepa in the Aitareya-brāhmaṇa (VII. 3) suggests that a son could be adopted oven when there was an aurasa son. The Taittiriya-samhita (VII. 1. 8. 1) tells the story of Atri who gavo an only son in adoption to Aurva. The Kṣetraja son of the Dharmasūtras is often referred to in the earliest Vedio literaturo. 'What (sacrificer) invites you (Asvins) in his house to a bed as a widow does a brother-in-law or a young damsel her lover '32. The Taittiriya-samhitā makes it clear that a father could distri bute his wealth among his sons during his own life-time, Manu divided his property among his sons' &c.33 Another passage of the same Sahitū seems to suggest that the eldest son took the whole of the father's wealth 'therefore people establish their eldest son with wealth '34. Even in the Vedic ages the son excluded the daughter from inheritance'a son born of the body does not give the paternal wealth to (his ) sister '35. A passage of the Taitti riya-saṁhitā is relied upon by ancient and modern writers on dharmaśāstra for the exclusion of women in general from inheri tance: therefore women being destitute of strength take no portion and speak more weakly than even a low person36. The Rgveda 
+[^32]: को वां॑ शयु॒त्रा वि॒धवे॑व दे॒वरं॒ मर्यं॒ न योषा॑ कृणुते स॒धस्थ॒ आ। ॠग्वेद X.40.2
 
-29 H antara arrunt: Fari al fua agā sa' Frar i esga X. 27. 12. 30 a fe gornto: lat stadiet agar $era VII. 5. 8. 31 जायमानो वै ब्राह्मणस्त्रिभिऋणवा जायते ब्रह्मचर्येण ऋषिभ्यो यज्ञेन देवेभ्यः प्रजया 
+[^33]: मनुः पुत्रेभ्यो दायं व्यभजत्। तै. सं. III.1.9.4. This passage is relied upon by आप​. ध​. सू. II.6.14.11. and बौ. ध​. सू. II.2.5.
 
-fapt: 1 32 \#tatargar jauda dai \#a giai gyd TFT BTT i Pede X. 40. 2 33 az qalazi HD 7HFT I Å. H. III. 1. 9. 4. This passage is relied 
+[^34]: तस्माज्ज्येष्ठं पुत्रं धनेन निरवसाययन्ति। तै. सं. II.5.2.7. This passage is referred to by आप​. ध​. सू. II.6.14. and बौ. ध​. सू. II.2.5.
 
-upon by 0119. 44. 7. 11. 6. 14. 11 and al. 27. . II. 2. 2. 34 JALUTUS ga yata atgarterais. À. II.5.2. 7. This passage is 
+[^35]: ‘न जा॒मये॒ तान्वो॑ रि॒क्थमा॑रैक्’  ॠग्वेद III.31.2; vide निरुक्त​ III.5. for explanations of this verse.
 
-referred to by 3774. 27. E. II. 6. 14. 12 and al. . . II. 2. 5. 35 'a arzat' fata RETE FEITE III. 31. 2; vide fart III. 5 for 
+[^36]: तस्मात्स्त्रियो निरिन्द्रिया अदायादीरपि पापात्पुंस उपस्तितरं वदन्ति। तै. सं. VI.5.8. Here the portion spoken of is really that of the _soma_ beverage. Vide बौ. ध​. सू. II.2.47. for reliance on this passage and also हरदत्त​ (on आप​. ध​. सू. II.6.14.1.) and सरस्वतीविलास​ (para. 21 and 336). Vide also शतपथब्रा. IV.4.2.13 for a similar passage.
 
-explanations of this verse. 36 Jeniant affair 3791912kia yrgregia guitai aamaria. VI.8. 
+[^37]: ब्र॒ह्म॒चा॒री च॑रति॒ वेवि॑ष॒द्विष॒: स दे॒वानां॑ भव॒त्येक॒मङ्ग॑म्। ॠग्वेद​ X.109.5. The शतपथपब्रा. (XI.5.4.18.) reads ‘तदाहुः । न ब्रह्मचारी सन्मध्वश्नीयात्.’ Compare मनु II.177. Vide शतपथपब्रा. XI.3.3.1. for _samidh_.
 
-Here the portion spoken of is really that of the soma bevdingo. Vide ... 9. II. 2. 47 for reliance on this passage and also grgh OR 19. 
+[^38]: इन्द्रो यतीन् सालावृकेभ्यः प्रायच्छत्।मेधातिथि (on मनु XI.45) quotes this Vide ऐ. ब्रा. 7.28. and ताण्ड्यमहाब्रा. 8.1.4, 13.4.17 and अथर्ववेद​ II.5.3.
 
-47. 8. il. 6. 14. 1) and hiriasia (para. 21 and 33641 Vido-Albo 779947. IV.4.2.13 for a similar passage. 
+[^39]: एष च श्रोत्रियश्चौतौ ह वै द्वौ मनुष्येषु धृतव्रतौ। शतपथ​ V.4.4.5.
 
-CSU 
+[^40]: तस्माच्छूद्रो यज्ञेऽनवकॢप्तः। तै. सं. VII.1.1.6.
 
-INS 
+[^41]: तद्यथैवादो मनुष्यराजे आगतेन्यस्मिन्वार्हत्युक्षाणं वा वेहतं वा क्षदन्त एवमस्मा एतत्क्षदन्ते यदग्निं मथ्नन्ति। ऐ. ब्रा. I.15. Compare वसिष्ठधर्मसूत्र​ 4.8 and या. I.109.
 
-FOUNDED 
+[^42]: पञ्च वा एते महायज्ञाः सतति प्रतायन्ते सतति सन्तिष्ठन्ते देवयज्ञः पितृयज्ञो भूतयज्ञो मनुष्ययज्ञो ब्रह्मयज्ञः। तै. आ. 2.10.7.
 
-Bhandarkar Oriental Research Institute 
+[^43]: उ॒च्चा दि॒वि दक्षि॑णावन्तो अस्थु॒र्ये अ॑श्व॒दाः स॒ह ते सूर्ये॑ण। हि॒र॒ण्य॒दा अ॑मृत॒त्वं भ॑जन्ते वासो॒दाः सो॑म॒ प्र ति॑रन्त॒ आयु॑:॥ ॠग्वेद​ X.107.2.
 
-2. Sources of Dharma 
+[^44]: धन्व॑न्निव प्र॒पा अ॑सि॒ त्वम॑ग्न इय॒क्षवे॑ पू॒रवे॑ प्रत्न राजन्। ॠग्वेद​ X.4.1.
 
-eulogises the stago of studenthood and the Satapathabrahmana speaks of the duties of the Brahmacarin such as not partaking of wine and offering every evening a samich to fire37. The Taittirlya-samhita (VI. 2. 8.5) relates38 how Indra consigned Yatis to wolves (or dogs) and how Prajāpati prescribed a Prāya scitta for him. The Satapathabrāhmana speaks of the king and the learned brahmana as the upholders of the sacred ordinances.39 The Taittirlyasamhitā says 'therefore the Sūdra is not fit for sacrifice'.' The Aitareya Brāhmaṇa tells us that when a king or other worthy guest comes, people offer a bull or a cowti. The Satapatha-brāhmana speaks of Vedic study as yajña and the Taittiriya-aranyakata enumerates the five yajnas, which are a prominent feature of the Manusmrti. The Rgveda eulogises the gifts of a cow, horses, gold and clothes43. Another passage of the Rgveda44 (thou art like a prapī in a desert) is relied upon by Sabara on Jaimini (I. 3. 2) and by Visvarupa on Yajnavalkya as ordaining the maintenance of prapūs (places where water is distributed to travellers). The Rgveda condemns the selfish 
+[^45]: केव॑लाघो भवति केवला॒दी। ॠग्वेद​ X.117.6.
 
-man who only caters for himself 45. 
-
-The foregoing brief discussion will make it clear that the later rules contained in the charmsūtras and other works on olurmuśāstra had their roots deep down in the most ancient Vodic tradition and that the authors of the dharmasūtras were quite justified in looking up to the Vedas as a source of dharma. 
-
-37 ब्रह्मचारी चरति वेविषद्विषः स देवानां भवत्येकमाम् । ऋग्वेद ४. 109. 5. The 
-
-शतपथपना. (XI. 5. 4. 18) reads 'तदाहुः। न ब्रह्मचारी सन्मध्वस्नीयात्.' 
-
-Compare मनु II. 177. vide शतपथब्रा. XI. 3.3.1 for samidh. 38 इन्द्रो यतीन् सालाकेभ्यः प्रायच्छत् । मेधातिथि (on मनु XI. 45) quotes this ____vide ऐ. ब्रा. 7. 28 and ताण्डयमहाब्रा. 8. 1. 4, 13. 4. 17 and अथर्ववेद II. 5. 3. 
-
-39 एष च श्रोत्रियश्चैतौ ह वै द्वौ मनुष्येषु धृतवती । शतपथ V. 4.4. 5. 40 तस्माच्छूद्रो यज्ञेऽनवक्लप्तः । तै. सं. VII. 1. 1. 6. 41 तयथैवादो मनुष्यराजे आगतेन्यस्मिन्वाहत्युक्षाणं वा वेहतं वा क्षदन्त एवमस्मा ___ एतत्क्षदन्ते यद िमश्नन्ति । ऐ. ब्रा. I. 15. Compare वसिष्ठधर्मसूत्र +. 8 and या. 
-
-I. 109. 42 पञ्च वा एते महायज्ञाः सतति प्रतायन्ते सतति सन्तिष्ठन्ते देवयज्ञः पितृयज्ञो भूतयज्ञो ___ मनुष्ययज्ञो ब्रह्मयज्ञः। तै. आ. 2. 10. 7. 43 उच्चा दिवि दक्षिणावन्तो अस्थुर्ये अश्वदाः सह ते सूर्येण । हिरण्यदा अमृतत्वं भनन्ते 
-
-वासोदाः सोम प्रतिरन्त आयुः ॥ ऋग्वेद X. 107. 2. 44 धन्वन्निव प्रपा असि त्वम॑ग्न यक्षवे' पूर्वे' प्रत्न राजन् । ऋग्वेद X. 4. 
-
-1 45 केवलाघो भवति केवलादी । ऋग्वेद X. 117.6. 
-
-FOUNDED 1917 
-
-% 
-
-10 
-
-History of Dharmaśāstra 
-
-But, as said above, the Vedas do not profess to be formal treatises on dharma; they contain only disconnected statements on the various aspects of dharma ; we have to turn to the smrtis for a formal and connected treatment of the topics of the dharmaśāstra. Vide Prof. S. C. Bannerjee's 'Dharmasūtras, a Study' pp. 514 533 for Vedic passages cited in major Dharmasūtras and pp. 533-539 for references to them by name or by initial word or words. 
-
-Before proceeding further a few preliminary remarks must be made. Ancient Sanskrit writers and modern historians of Sanskrit Literature divide ancient Sanskrit works into three groups, viz. the Vedic Samhitās (Rgveda, Yajurveda, Sama voda and Atharvaveda ), the Brāhmaṇas (including the early Upaniṣads like the Bșhadāraṇyaka). and Sūtras. The first two groups together constitute Veda or Śruti ( as Sabara says on P. M. S. II. 1. 33 'Mantrās-ca Brāhmaṇam ca Vedah '). Sūtras are not Veda, but many of thom are connected with the Veda and contain numerous mantras. Kalpa is one of the six auxiliary lores (angas) of the Voda and this group is generally later in time than the Brāhmanas, though some sūtra works appear to have been composed even in the times of the Tai. Ār. II. 10 and of the Brhadārangakopaniṣad (II. 4.10 and IV. 5. 11). A distinction is drawn between Kalpa and Kalpasūtra by tho Tantravārtika.45a The word Kalpa (or rather Kalpasutra) is used in two senses, one comprehensive including tho aphoristic works on Vedic ritual, on the domestic ceremonies and also on law, government and administration of justice; the other sense covers only those aphoristic works that deal with Vedic sacrifices and matters related thereto. If the first sense is taken then Kalpasūtras are classified into three classes, viz. Srautasūtras that deal with solemn Vedic sacrifices, mentioned or discussed in the Vedas and Brāhmanas; (2) Grhyasūtras that deal with domestic ceremonies such as Upanayana, marriage and with daily and periodical rites and employ mantras for them mostly from one Sākhā of the Veda; (3) Dharmasūtras (also depending on the Vedas as the highest authority ) that treat of some of the topics dealt with in the Gșhyasūtras but add provisions on matters .concerning economic life, politics, government, civil and criminal law. A complete Kalpa in the first sense should cover all the three divisions. It is highly doubtful whether gxth Veda 
-
-45 a on P. M. S. I, 3, 11 (for which vide H. of Dh. VOR Collor 1844 n. 
-
-2077). 
-
-1917 
-
-2. Sources of Dhitrina 
-
-11 
-
-Śākhā had originally a complete set of the three kinds of works covered under the word Kalpa. This will be briefly dealt with a little below. 
-
-Recently (1959) Dr. Ram Gopal has brought out a large work on 'India of Vedic Kalpasūtras' containing over five hundred closely printed pages. The title of the work is rather misleading. It does not deal with the Srautasūtras beyond very briefly stating what they contain and distinguishing their contents from those of the Gșhya and Dharmasūtras. His work is concerned only with the details gathered from the Gșhya and Dharınasūtras and he has nothing to say about the development of the several topics dealt with in these two classes during the long period of at least 2000 years after the sūtra period (which he places between 800 - 500 B. C. on p. 89). His work should have been entitled "Indian Life as depicted in Gșhya and Dharmasūtras". As far as it goes it is a tolerable thesis, though rather prolix, dogmatic and over-disputatious. Having confined himself to the Gphya and Dharmasūtras, it should have been his business to discuss all points concerning at least the principal Gļhya and Dharmasūtras. But he leaves important matters concerning several sūtras untouched. For example, on p. 54 he observes 'many sūtras in the Gaut. Dh. S. appear to be of doubtful authenticity and it is an important task for future reseurchers to determine precisely the spurious sūtras interpolated in the original Dharmasūtra'. One feels that he should himself have tackled that task at least about some representative Gșhya sūtras and the Gautama- dharma-sūtra ( which he places on p. 84 among the oldest class of Srauta, Grhya and Dharmasūtras and when on p. 82 he holds that Gautama is undoubtedly the oldest writer on Smārta Dharma) by a thorough examination of chapters and passages in them and should have pointed out the criteria why certain gūtras are held to be spurious and so forth. He need not have included in the thesis the description of the flora and fauna &c. (pp. 103-109) or if he wanted to include these subjects he should have devoted more space. Nor was there any need for him to discuss (as he does on pp. 100-103 ) the varying limits of Aryavarta, since that subject had been dealt with at length by me in H. of Dh. Vol. II pp. 11-16. Ho hardly adds anything substantial to what I stated on that topic twenty two years ago. He could have referred to Vol. II of H. Dh, pp. 11-16 and added bits of information that did not getur therein. 
-
-.!!!12 
-
-History of Dharmaśāstra 
+[^45a]: On P.M.S. I, 3, 11, (for which vide H. Of Dh. Vol. V. 127 n. 2077).


### PR DESCRIPTION
* Fix the markup and typos in `content/kANe/v1p1/02_sources_of_dharma.md`. 
* Add clickable footnotes.
* Corrected a possible typo in the original footnote referring `न॒हि ग्रभा॒यार॑णः सु॒शेवो॒ऽन्योद॑र्यो॒ मन॑सा॒ मन्त॒वा उ॑` from `ॠग्वेद​ VII.5.8.` instead of `ॠग्वेद​ VII.4.8.`.