### PR TITLE
Fix v1p1ch03

### DIFF
--- a/kANe/v1p1/03_date_of_dharmashAstra_works.md
+++ b/kANe/v1p1/03_date_of_dharmashAstra_works.md
@@ -3,97 +3,20 @@ title = "03 When Dharmasastra works were first composed"
 short_title = "03 Date of Dharmaśāstra works"
 
 +++
-<!-- 03 Date of Dharmaśāstra works
-3. When Dharmasastra works were first composed  -->
 
-The important question is to find out when formal treatises on _dharma_ began to be composed. It is not possible to give a definite answer to this question. The Nirukta (III. 4-5) shows that long before Yāska heated controversies had raged on various questions of inheritance, such as the exclusion of daughters by sons and the rights of the appointed daughter (putrikā). It is very likely that these discussions had found their way in formal works and were not merely confined to the meetings of the learned. The manner in which Yāska writes suggests that he is referring to works in which certain Vedic verses had been cited in support of particular doctrines about inheritance[^46]. It is further a remarkable thing that in connection with the topic of inheritance Yāska quotes a verse, calls it a Śloka and distinguishes it from a ṛk.[^47] This makes it probable that works dealing with topics of _dharma_ existed either composed in the śloka metre or containing ślokas. Scholars like Bühler would say that the verses were part of the floating mass of mnemonic verses, the existence of which he postulates without very convincing or cogent arguments in his Introduction to the Manusmṛti (S. B. E. vol. 25 Intro.xc). If works dealing with topics of _dharma_ existed before Yāska, a high 
+The important question is to find out when formal treatises on _dharma_ began to be composed. It is not possible to give a definite answer to this question. The Nirukta (III. 4-5) shows that long before Yāska heated controversies had raged on various questions of inheritance, such as the exclusion of daughters by sons and the rights of the appointed daughter (putrikā). It is very likely that these discussions had found their way in formal works and were not merely confined to the meetings of the learned. The manner in which Yāska writes suggests that he is referring to works in which certain Vedic verses had been cited in support of particular doctrines about inheritance[^46]. It is further a remarkable thing that in connection with the topic of inheritance Yāska quotes a verse, calls it a Śloka and distinguishes it from a ṛk.[^47] This makes it probable that works dealing with topics of _dharma_ existed either composed in the śloka metre or containing ślokas. Scholars like Bühler would say that the verses were part of the floating mass of mnemonic verses, the existence of which he postulates without very convincing or cogent arguments in his Introduction to the Manusmṛti (S. B. E. vol. 25 Intro.xc). If works dealing with topics of _dharma_ existed before Yāska, a high antiquity will have to be predicated for them. The high antiquity of works on _dharmaśāstra_ follows from other weighty considerations. It will be seen later on that the extant _dharmasūtras_ of Gautama, Baudhāyana and Āpastamba certainly belong to the period between 600 to 300 B. C. Gautama 48 speaks of _dharmaśāstras_ and the word _dharmaśāstra_ occurs in Baudhāyana also (IV. 5.9). Baudhāyana speaks of a _dharmapāṭhaka_ (I. i. 9.). Besides, Gautama quotes in numerous places the views of others in the words 'ityeke' (e.g. II. 15, II, 58, III. 1, IV. 21, VII. 23). He refers to Manu[^49] in one place and to 'Ācāryas' in several places (III. 35, IV.18). Baudhāyana mentions by name several writers on dharma, viz. Aupajaṇghani, Kātya, Kāśyapa, Gautama, Maudgalya and Hārīta. Āpastamba also cites the views of numerous sages such as those of Eka, Kaṇva, Kautsa, Hārīta and others. There is a Vārtika which speaks of Dharmaśātra[^50]. Jaimini speaks of the duties of a Śūdra as laid down in the dharmaśātra[^51]. Patañjali shows that in his days _dharmasūtras_ existed and that their authority was very high, being next to the commandments of God[^52]. He quotes verses and dogmas that have their counterparts in the dharmasūtras[^52a]. The foregoing discussion establishes that works on the _dharmaśāstra_ existed prior to Yāska or at least prior to the period 600-300 B.C. and in the 2nd century B.C. they had attained a position of supreme authority in regulating the conduct of men. 
 
-<!-- [^47]: तदेतहक्लोकाभ्यामभ्युक्तम्। अङ्गादकात्सम्भवसि...स जीव शरदः शतम् ।। 
+In this book the whole of the extant literature on dharma will be dealt with as follows:- First come the _dharmasūtras_, some of which like those of Āpastamba, Hiraṇykeśin and Baudhāyana form part of a larger Sūtra collection, while there are others like those of Gautama and Vasistha which do not form part of a larger collection; some _dharmasūtras_ like that of Viṣṇu are, in their extant form, comparatively later in date than other _sūtra_ works; some _sūtra_ works like those of Śaṅkha-Likhita and Paiṭhīnasi are known only from quotations. Then early metrical smṛtis like those of Manu and Yājñavalkya will be taken up for discussion; then later versified smṛtis like that of Nārada; there are many smṛti works like those of Bṛhaspati and Kātyāyana that are known only from quotations. The two epics, the Mahābhārata and the Rāmāyaṇa, and the Purāṇas also have played a great part in the development of the Dharmaśāstra. The commentaries on the smṛtis, such as those of Viśvarūpa, Medhātithi, Vijñāeśvara, Aparārka, Haradatta will be next passed in review and then the digests on _dharma_ such as the works of Hemādri, Todaramalla, Nīlakaṇṭha and others. 
 
-अविशेषेण पुत्राणादायोभवति धर्मतः। मिथुनानां विसर्गादो मनुः स्वायम्भुवोब्रवीत् ।।. The first half of the verse 'Aigād-angat' occurs in. Br. Up. VI. 4.9 and in Kauṣitaki Up. 2. 11 (three pādas) and the whole verse in Baud. Gs. and Aśv G§. and in mantra-patha II. 11. 33. The Māpavagṛhyasūtra (I. 18. 1) provides that the verse 'angad-angat,' quoted io n. 47, was to be muttered over the son's head after the father returned from a journey. It may be noted that in the extant Manusmrti 
+It is very difficult to settle the chronology of the works on dharmaśāstra, particularly of the earlier ones. The present writer does not subscribe to the view of Max Müller (H. A. S. L. p. 68) and others that works in continuous Anuṣṭubh metre followed sūtra works[^53]. Our knowledge of the works of that period is so meagre that such a generalisation is most unjustifiable. Some works in the continuous śloka metre like the Manusmṛti are certainly older than the Viṣṇudharmasūtra and probably as old as, if not older than, the Vasiṣṭhadharmasūtra. One of the earliest extant dharmasūtras, that of Baudhāyana, contains long passages in the śloka metre, many of which are quotations and even Āpastamba has a considerable number of verses in the śloka metre. This renders it highly probable that works in the śloka metre existed before them. Besides, a large literature on _dharma_ existed in the days of Āpastamba and Baudhāyana which has not come down to us. In the absence of that literature it is futile to dogmatise on such a point.
 
-Manuh SvāyambhuvoSbravīt' occurs in IX. 158 and the words * Manurāha Prajāpatih' occur in X. 78 and the words' tan-Manoranu. sasanam'occur in VIII. 139 and 279 and in IX. 239. This shows that the śloka quoted by the Nirukta might have been contained in some Smrti work like the extant Manusmrti. Vide Manu IX. 133 and 139 for the underlying idea that there is no difference between the son's son and the daughter's son and therefore between sop and daughter. 
+In volumes II to V both Śrautasūtras and G	ṛhya-sūtras have been quoted and relied upon very frequently. In pp. 976-1255 of Volume II a comparatively full account was given of the Vedic sacrifices based on the 	Śrautasūtras. But no account of the Gṛhyasūtras in general was given in any of the five volumes of the History of Dharmaśāstra. Therefore, a brief statement on the gṛhyasūtras with references to some printed editions is set out below and no attempt will be made to settle their chronology. The chronology of the Dharmaśāstra given later on may be held applicable to the Gṛhyasūtras also with some unimportant modifications. The Gṛhyasūtras often refer to the Śrautasūtras of their schools e.g. the Āśv. Gṛ, begins 'uktāni vaitānikāni gṛhyāni vāksyāmaḥ' (the Śrauta sacrifices have been already expounded; we shall now expound the gṛhya rites). Vitāna means, acc. to Amarakośa, 'kratu' (vedic sacrifice) and 'vistāra'. Gṛhya is derived from 'gṛha' which means 'house or a shed' or 'wife' ('gṛhini gṛhamucyate' in Sānti-parva 144.6 Ch ed.). The gṛhya fire was set up by a man at or after marriage or on partition of inheritance. Vide Āśv. Gṛ. S. I. 61 (Pānigrahaṇād gṛhyam paricaret), H. of Dh. Vol. II p. 678 note 1615 for other texts; Āp. Dh. S. II.7. 17. 16 'Sarveṣu vṛtteṣu sarvataḥ samavadāya prāśnīyād-yādthoktam' has in view Āp. Gṛ. S. VIII. 2 1. (khaṇḍa). 9. Similarly, Āp. Dh. S. I. 1. 14. 16, II. 2. 3.17, II. 2. 5. 4. refer to provisions in Āp. Gṛ. S. [^53a] Similarly, a gṛhyasūtra has often in view the Dharmasūtra of its _caraṇa_; e.g. Āp. Gṛ. 8. 21. 1. (māsiśrāddhasyāparapakṣe yathopadeśam kālāḥ) has in view Āp. Dh. S. II. 7. 16. 4-21. It may be noted that Āp. Gṛ. IV. 11. 16-17 ( Pālāso daṇḍo...upadiśānti) occur as Āp. Dh. S. I. 1. 2. 38. It may plausibly be argued that the extant Śrauta, Gṛhya and Dharmasūtras of certain _caraṇas_ like those of Āpastamba and Baudhāyana were composed either by one and the same person or at least by father and son or grandfather and grandson and so on. But this would not be correct in the case of several Dharmasūtras. 
 
-As stated in Gautama, Manu, Yaj. and others, Srutt and Smrti are the most authoritative sources of Dharma and Manusmrti II. 10 states that Smsti Is Dbarmasastra. This last in a broad sense comprises the Gṛhya and Dharmasūtras, metrical smstis like those of Mann. Yaj, Brhaspati, Parāśara, commentaries on them and digests | pibandhas).  -->
-
-
-antiquity will have to be predicated for them. The high antiquity of works on _dharmaśāstra_ follows from other weighty considerations. It will be seen later on that the extant _dharmasūtras_ of Gautama, Baudhāyana and Āpastamba certainly belong to the period between 600 to 300 B. C. Gautama 48 speaks of _dharmaśāstras_ and the word _dharmaśāstra_ occurs in Baudhāyana also (IV. 5.9). Baudhāyana speaks of a _dharmapāṭhaka_ (I. i. 9.). Besides, Gautama quotes in numerous places the views of others in the words 'ityeke' (e.g. II. 15, II, 58, III. 1, IV. 21, VII. 23). He refers to Manu[^49] in one place and to 'Ācāryas' in several places (III. 35, IV.18). Baudhāyana mentions by name several writers on dharma, viz. Aupajaṇghani, Kātya, Kāśyapa, Gautama, Maudgalya and Hārīta. Āpastamba also cites the views of numerous sages such as those of Eka, Kaṇva, Kautsa, Hārīta and others. There is a Vārtika which speaks of Dharmaśātra[^50]. Jaimini speaks of the duties of a Śūdra as laid down in the dharmaśātra[^51]. Patañjali shows that in his days _dharmasūtras_ existed and that their authority was very high, being next to the commandments of God[^52]. He quotes 
-
-<!-- 48 tit. 7. 8. 9.21 'att 5 OJTERT OTT Å TENTOT Fifa sjaar: grina'. ___The words पृथग्धविदत्रयः in गौ ध. स. 28. 47 appear to refer to 
-
-___ students of धर्मशास्त्र. 49 sifu 1941-alasqıla 49: 1 fit. 17. 7. 21. 7. 50 धर्मशास्त्रं च तथा । Vide महाभाष्य vol. I. p. 242. 51 ÅTELIT 1 q. 51. F. VI. 7.6. 52 नैवेश्वर आज्ञापयति नापि धर्मसूत्रकाराः पठन्ति अपवादैरुत्सर्गा बाध्यन्तामिति । 
-
-HETITIEvol. I, p. 115 and vol. II, p. 365. qal quotes 311912 form: faatu sifar: (vol. I. p. 14.) for which vide 2014. 7. 9. I. 7.20 3 'तद्यथाने फलार्थे निमित्ते छाया गन्ध इत्यनूत्पयेते.' पतञ्जलि says 'तैलं न विक्रेतव्यं मांसं न विक्रेतव्यम् ' and लोमनखं स्पृक्षा शौचं कर्तव्यम् (vol. I. p. 25). The words Damat gufa may also mean ' A king (ruler) does not command' &c. The Gaut. Db. S. IX. 53 provides that a learned brāhmaṇa may approach a ruler for his own 'yogakṣema'. Similarly. the Mahābhāṣya itself (Vol. III. p. 7) on Vārtika 9 on Pān. VI. 1.2 bas the words SEAT 37iigīa TAITATA149691 3 eraia,' where 'Isvara' can only mean 'king or ruler.' Panini in I, 4. 97 (adhir. iśvale) and in II. 3. 39 uses Isvara in the sense of ruler or owner. There is not much to choose between the two senses. If Isvara' is taken to mean 'God'the meaning would be 'God (i. e. Veda, the word of God ) does not order &c. Vide TR. 39. II. 4.10 TRI PERT Haki faizdiharaagaat oc: magistariefta:' on which the Vedāntasūtra (1.1.3) magliaraia is based. 
-
-14 
-
-History of Dharmaśāstra  -->
-
-verses and dogmas that have their counterparts in the dharmasūtras[^52a]. The foregoing discussion establishes that works on the _dharmaśāstra_ existed prior to Yāska or at least prior to the period 600-300 B.C. and in the 2nd century B.C. they had attained a position of supreme authority in regulating the conduct of men. 
-
-In this book the whole of the extant literature on dharma will be dealt with as follows:- First come the _dharmasūtras_, some of which like those of Āpastamba, Hiraṇykeśin and Baudhāyana form part of a larger Sūtra collection, while there are others like those of Gautama and Vasistha which do not form part of a larger collection; some _dharmasūtras_ like that of Viṣṇu are, in their extant from, comparatively later in date than other _sūtra_ works; some _sūtra_ works like those of Śaṅkha-Likhita and Paiṭhīnasi are known only from quotations. Then early metrical smṛtis like those of Manu and Yājñavalkya will be taken up for discussion; then later versified smṛtis like that of Nārada; there are many smṛti works like those of Bṛhaspati and Kātyāyana that are known only from quotations. The two epics, the Mahābhārata and the Rāmāyaṇa, and the Purāṇas also have played a great part in the development of the Dharmaśāstra. The commentaries on the smṛtis, such as those of Viśvarūpa, Medhātithi, Vijñāeśvara, Aparārka, Haradatta will be next passed in review and then the digests on _dharma_ such as the works of Hemādri, Todaramalla, Nīlakaṇṭha and others. 
-
-It is very difficult to settle the chronology of the works on dharmaśāstra, particularly of the earlier ones. The present writer 
-
-<!-- 52a. A few passages from the Mahābhāgya having a striking identity or 
-
-similarity to Dharmasūtra texts may be cited bere. (1) spiega दूरात्पादावसेचनम् । दूराच्च भाव्यं दस्युभ्यो दूराच्च कुपितागुरोः ॥ महाभाष्य (vol. I. p. 457) on aird 2 on 97. II. 3. 35: compare tit. 7. F. 9. 39, 3719. 47. 7. 1. 11. 31.2. Ag IV. 151 ( first half), ang798 104.82: (2) z ale print yarā dat 391:ant 6199169 Vol. 11, p. 99 on airco 2 on 9. III 2. 8; compare alguna 21.11 ; (3) ऊर्ध्वं प्राणा ह्यामन्ति यूनः स्थविर आयति। प्रत्युत्थानाभिवादाभ्यां पुनस्तान् ganga || FETTO, vol. III. p. 58 on quita 5 op 91. VI. 1. 84, which is HET II. 120 and 2 auha 120. 64-65 and all 38.1 (37. 1 in some editions); (4) THICH SET 3989 sa Haqn14 : at sfat par पुनः प्रवृत्तिने भवति तथा त्रिदयंगमाभिरद्भिरशद्वाभिरुपस्पृशेदिति सकृदुपस्पृश्य कृतः SITE sia mai ga: sila para I HE7271677 Vol III. p. 537 on aina 4 on 91. VI. 1.84 ; compare alguna III. 31. A 
-
-Volume and page references relate to Kielboro's ed. of the HEL91944. Vide the author's paper in Prof. F. W. Thomas Presentation vol. pp. 128-131. 
-
-HASTUV 
-
-FOUNDED 
-
-1917 
-
-3. When Dharmaśāstra works were first composed 
-
-15  -->
-
-does not subscribe to the view of Max Müller (H. A. S. L. p. 68) and others that works in continuous Anuṣṭubh metre followed sūtra works[^53]. Our knowledge of the works of that period is so meagre that such a generalisation is most unjustifiable. Some works in the continuous śloka metre like the Manusmrti are certainly older than the Viṣṇudharmasūtra and probably as old as, if not older than, the Vasiṣṭhadharmasūtra. One of the earliest extant dharmasūtras, that of Baudhāyana, contains long passages in the śloka metre, many of which are quotations and even Āpastamba has a considerable number of verses in the śloka metre. This renders it highly probable that works in the śloka metre existed before them. Besides, a large literature on _dharma_ existed in the days of Āpastamba and Baudhāyana which has not come down to us. In the absence of that literature it is futile to dogmatise on such a point.
-
-In volumes II to V both Śrautasūtras and G	ṛhya-sūtras have been quoted and relied upon very frequently. In pp. 976-1255 of Volume II a comparatively full account was given of the Vedic sacrifices based on the 	Śrautasūtras. But no account of the Gṛhyasūtras in general was given in any of the five volumes of the History of Dharmaśāstra. Therefore, a brief statement on the gṛhyasūtras with references to some printed editions is set out below and no attempt will be made to settle their chronology. The chronology of the Dharmaśāstra given later on may be held applicable to the Gṛhyasūtras also with some unimportant modifications. The Gṛhyasūtras often refer to the Śrautasūtras of their schools e.g. the Āśv. Gṛ, begins 'uktāni vaitānikāni gṛhyāni vāksyāmaḥ' (the Śrauta sacrifices have been already expounded; we shall now expound the gṛhya rites). Vitāna means, acc. to Amarakośa, 'kratu' (vedic sacrifice) and 'vistāra'. Gṛhya is derived from 'gṛha' which means 'house or a shed' or 'wife' ('gṛhini gṛhamucyate' in Sānti-parva 144.6 Ch ed.). The gṛhya fire was set up by a man at or after marriage or on partition of inheritance. Vide Āśv. Gṛ. S. I. 61 (Pānigrahaṇād gṛhyam paricaret), H. of Dh. Vol. II p. 678 note 1615 for other texts; Āp. Dh. S. II.7. 17. 16 'Sarveṣu vṛtteṣu sarvataḥ samavadāya prāśnīyād-yādthoktam' has in view Āp. Gṛ. S. VIII. 2 1. (khaṇḍa). 9. Similarly, Āp. Dh. S. I. 1. 14. 16, II. 2. 3.17, 
-
-<!-- ystyna 
-
-WYN 
-
-53 Vide S. B. E. vol. II, p. IX, but see Goldstücker s ' Panini R 59. 
-
-60,78) against Max Müller and Prof. D. R. Bhandarkar's armida ael lectures for 1918, pp. 105-107, 
-
-A 
-
-FOUNDED 
-
-1917 
-
-16 
-
-History of Dharmaśāstra  -->
-
-II. 2. 5. 4. refer to provisions in Āp. Gṛ. S. [^53a] Similarly, a gṛhyasūtra has often in view the Dharmasūtra of its _caraṇa_; e.g. Āp. Gṛ. 8. 21. 1. (māsiśrāddhasyāparapakṣe yathopadeśam kālāḥ) has in view Āp. Dh. S. II. 7. 16. 4-21. It may be noted that Āp. Gṛ. IV. 11. 16-17 ( Pālāso daṇḍo...upadiśānti) occur as Āp. Dh. S. I. 1. 2. 38. It may plausibly be argued that the extant Śrauta, Gṛhya and Dharmasūtras of certain _caraṇas_ like those of Āpastamba and Baudhāyana were composed either by one and the same person or at least by father and son or grandfather and grandson and so on. But this would not be correct in the case of several Dharmasūtras. 
-
-The gṛhyasūtras belong to the various recensions of the four vedas The gṛhyasūtras translated in volumes XXIX and XXX of the Sacred Books of the East Series are in order Śāṅkhāyana, Āśvalāyana, Pāraskara,Khādira, Gobhila, Hiraṇyakeśin, Āpastamba. The Dharmasūtras translated in Sacred Books of the East Vol. II, VII and XIV are those of Āpastamba, Gautama, Viṣnu, Vasiṣṭha and Baudhāyana. The gṛhyasūtras belonging to the Ṛgveda are : (1) Āśvalāyana gṛ. s., published with Nārāyaṇa's commentary by Nir. Press and in B. I. Series and with Anāvilā of Haradatta in Tri. S. S. (1923). This Gṛ. S. belongs to the Śākala Śākhā and the last verse in the Śākhā of the Ṛg. is 'Samānīva ākūtiḥ'; (2) The Śāṅkhāyana Gṛ. S. (in six adhyāyas of which the last two appear to be later additions) commented upon by Nārāyana and published in Indische Studien, Vol. XV. pp. 1-166, and by Dr. G. R. Sehgal with a learned Introduction (1960), New Delhi; (3) The Kauṣītaka (often written as Kauṣītaki) Gṛ. S. edited by Mr. Ratna Gopal Bhatta (in the Benares S. Series, 1908) and by Dr. T. R. Chintamani, Madras, 1944 with the commentary of Bhavatrāta. These two belong to the Bāśkala Śākhā of the Ṛgveda, the last verse of which is 'tac-chaṃ-yorāvṛṇīmahe.' 
+The gṛhyasūtras belong to the various recensions of the four vedas The gṛhyasūtras translated in volumes XXIX and XXX of the Sacred Books of the East Series are in order Śāṅkhāyana, Āśvalāyana, Pāraskara,Khādira, Gobhila, Hiraṇyakeśin, Āpastamba. The Dharmasūtras translated in Sacred Books of the East Vol. II, VII and XIV are those of Āpastamba, Gautama, Viṣnu, Vasiṣṭha and Baudhāyana. The gṛhyasūtras belonging to the Ṛgveda are: (1) Āśvalāyana gṛ. s., published with Nārāyaṇa's commentary by Nir. Press and in B. I. Series and with Anāvilā of Haradatta in Tri. S. S. (1923). This Gṛ. S. belongs to the Śākala Śākhā and the last verse in the Śākhā of the Ṛg. is 'Samānīva ākūtiḥ'; (2) The Śāṅkhāyana Gṛ. S. (in six adhyāyas of which the last two appear to be later additions) commented upon by Nārāyana and published in Indische Studien, Vol. XV. pp. 1-166, and by Dr. G. R. Sehgal with a learned Introduction (1960), New Delhi; (3) The Kauṣītaka (often written as Kauṣītaki) Gṛ. S. edited by Mr. Ratna Gopal Bhatta (in the Benares S. Series, 1908) and by Dr. T. R. Chintamani, Madras, 1944 with the commentary of Bhavatrāta. These two belong to the Bāśkala Śākhā of the Ṛgveda, the last verse of which is 'tac-chaṃ-yorāvṛṇīmahe.' 
 
 The Yajurveda has two recensions Kṛṣṇa and Śukla. The former has come down to us in four schools viz. Taittiriya, Maitrāyaṇiya, Kāṭhaka and Kapiṣṭhala-kaṭha. The number of Śrauta and Gṛhya-sūtras belonging to the Kṛṣṇayajurveda is large. The more important of the Gṛ. Sutras are
 
 1. Baudhāyana Gṛ. S. (published in Mysore Government's Oriental Library Series, 1920);
-
-<!-- STV 
-
-53 A 3719. 7. I. 1. 19. (qanal: FATT OTPITHAT: qfiam s ider: 
-
-पात्रप्रोक्ष इति दर्शपूर्णमासस्तूष्णीम्). This extends four marters from the Ap. Śr. (1. 11. 7., 1., 11. 6. 1. 11. 9 and 1. 11. 10 pospellyhy) to gṛhya rites. 
-
-FOUNDEO 
-
-1917 
-
-8. When Dharmaśāstra works were first composed 
-
-17  -->
 
 2. Bhāradvāja Gṛhya (in three _praśnas_) edited by Dr. Henriette J. W. Salomons at Leiden, who gives extracts from the Bhāṣyakāra of that sūtra; 
 
@@ -103,21 +26,7 @@ FOUNDEO
 
 5. The Mānava-gṛhyasūtra (also called Maitrāyanīya-Mānavagṛhya) edited by Dr. Knauer and in the G. 0. Series with Aṣṭāvakra's bhāṣya; the sūtra is divided into two parts called _puruṣa_; the bhāṣya calls the work Pūraṇa and ascribes it to Mānavācārya; 
 
-6. Vaikhānasa-smārta-sūtra in ten praśnas, 7 on gṛhya and 3 on dharma-published at Kumbhakonam in 1914, and by Dr. Caland in B. I. Series with English translation (1927 and 1929). The Mantras[^53c] required are indicated by the opening words only (pratīkas). 
-
-<!-- 536 This mantrapātha was most probably compiled before the Gṛhyasūtra 
-
-as it forms praśnas 25 and 26 of the Āpastambīya-kalpa aud as the Ap. 
-
-Gṛhya forms only the 27th praśna 53 c The Ait, Br. (adbyāya 3, kbaṇda 5) states' etadvai yajñasya samfddbam 
-
-yad-rūpasamfddham yat karma kriyamānam fg-abhivadatīti,' The Nirukta (I, 16) quotes this passage but the words 'yajur-vā' after 'rg'. are added in mss. and editions. Jaimini affirms that there is no difference in the meanings of words employed in the Veda and ordinary lile (P. M.S. I 2.32 'avisistastu vākysrthaḥ') and Sabara remarks on this that mantras are recitel in sacrifices for the purpose of conveying the meaning of wbat is being done (arthapratyāyanārtham-eva yajñe mantroccāraṇam). In this connection, vide Prof. M. V. Apte's paper 'The Ṛgveda mantras in their ritual setting in the grbyasūtras' published in the Bulletin of the D. C. R. I. (Poona) Vol. I. pp 14-44 and 127-152 and also his paper in Prof. Kunban Raja Presentation Vol. pp. 233-240 where he concludes that the word mantra in the gfhyasūtras came to have an extended meaning so as to comprise all types of liturgical formulae, metrical or prose &c.; vide H, of Dhoom . 
-
-V. pp. 1220-1223 about Vedic Mantras, 
-
-18 
-
-History of Dharmaśāstra  -->
+6. Vaikhānasa-smārta-sūtra in ten praśnas, 7 on gṛhya and 3 on dharma-published at Kumbhakonam in 1914, and by Dr. Caland in B. I. Series with English translation (1927 and 1929). The Mantras[^53c] required are indicated by the opening words only (pratīkas).
 
 7. Kāṭhakagṛhyasūtra, also called Carakagṛhya, Laugākṣigṛhya or Cārāyaṇīyagṛhya, edited by Dr. Caland in D. A. V. College Series at Lahore in 1925 with extracts from three commentaries, viz. Vivaraṇa of Ādityadarśana, Paddhati of Brāhmaṇabala and bhāṣya of Devapāla. Kashmirian tradition ascribes the work to Laugākṣi. 
 
@@ -131,29 +40,11 @@ The Gṛhyasūtras belonging to the Śukla Yajurveda (Mādhyandina and Kāṇva 
 
     I am inclined to hold that Pāraskara is another name of Kātyāyana, 'Pāraskara-prabhṛtīni; ca saṃjñāyām' Pāṇ. VI. I. 157, on which the Mahābhāṣya says 'Pāraskaro deśaḥ'; Kātyāyana came probably from that country and was called Pāraskara also. Nāgojibhaṭṭa and other writers have assigned other meanings to that word by saying 'pāram karoti Pāraskaraḥ.'
 
-2. Baijavāpagṛhya:-vide Proceedings and Transactions of the 4th Oriental Conference at Allahabad, Vol. II pp. 59-67 where Pandit Bhagavad-datta gives a good deal of information and puts together on pp. 63-67 passages of Baijavāpa-gṛhya from 14 medieval works. Kumārilabhaṭṭa in Tantravārtika on P. M. S. I. 3. 11 appears to refer to the work of Baijavāpa (or-pi) [^53e] 
-<!-- 
-53 cl Vide, for an incomplete ms. of Bhartryajña, Catalogue of S, Mss of the 
-
-Asiatic Society of Bengal, Vol. II. NO. 1023 and I. H. Q. Vol. XII 
-
-pp. 494-503, where it is shown that Karka knew Bhartfyajila. 53 e 31194319aai Hai Hatano 0911 Aurofiz. JIÊZ-1iiganaila 
-
-gairaz on q. 1. 1. 3. 11, p. 229 (Aoan. ed.). 
-
-It is possible that the reference here may be to the Śrauta or Gṛhyasūtra of Baijavāpi or to both, just as we bave a śrauta sūpe and a grbyasūtra of Afvalāyana. 
-
-STITUD 
-
-44 TL 
-
-4. The Gṛhya and Dharmasūtras 
-
-19  -->
+2. Baijavāpagṛhya:-vide Proceedings and Transactions of the 4th Oriental Conference at Allahabad, Vol. II pp. 59-67 where Pandit Bhagavad-datta gives a good deal of information and puts together on pp. 63-67 passages of Baijavāpa-gṛhya from 14 medieval works. Kumārilabhaṭṭa in Tantravārtika on P. M. S. I. 3. 11 appears to refer to the work of Baijavāpa (or-pi) [^53e].
 
 The gṛhyasūtras belonging to the Sāmaveda are : 
 
-1. Gobhilagṛhyasūtra, published in the B. I. series ; published in the Calcutta Sanskrit series with the com. of Nārāyaṇa, edited by Chintamani Bhattācārya (1936). The mantras required in gṛhya rites are collected in a Mantrabrāhmaṇa and the sūtra mentions only the opening words, but where the mantras are not contained in the Mantrabrāhmana they are quoted in full; this mantrapātha called Mantrabrāhmaṇa was most probably compiled before the Gobhila Gṛ. S. 
+1. Gobhilagṛhyasūtra, published in the B. I. series; published in the Calcutta Sanskrit series with the com. of Nārāyaṇa, edited by Chintamani Bhattācārya (1936). The mantras required in gṛhya rites are collected in a Mantrabrāhmaṇa and the sūtra mentions only the opening words, but where the mantras are not contained in the Mantrabrāhmana they are quoted in full; this mantrapātha called Mantrabrāhmaṇa was most probably compiled before the Gobhila Gṛ. S. 
 
 2. The Khādiraghya-sūtra, published in the Mysore Govt. Library Series with the com. of Rudraskanda, son of Nārāyana. This is based on the Gobhila Gṛ. S. and is an abridgement of it; 
 
@@ -163,6 +54,47 @@ The gṛhyasūtras belonging to the Sāmaveda are :
 
 The Atharvaveda has the Kauśika-sūtra as its Gṛhya. which was edited by Prof. Bloomfield. Vide Prof. Belvalkar Presentation Vol. pp. 28-33 for a paper by Mr. C. G. Kashikar for corrections in it and a paper 'Kauśikasūtra and the Atharvaveda' by Prof. Edgerton in F. W. Thomas Presentation Vol. pp. 78-81. There are several commentaries on it. It devotes a large part of it to _utpātas_ and _śāntis_. 
 
--- TODO REFERENCES FROM HERE --v (Page 12 in the source text)
-
 [^46]: अयैतां जाम्या रिक्थप्रतिषेध उदाहरन्ति ज्येष्टं पुत्रिकाया इत्येके । Vide S. B. E. vol. 25, LXI (footnote) for Bühler's view refuting Roth's opinion that the whole discussion in the Nirukta is an interpolation.
+
+[^47]:
+    तदेतहक्लोकाभ्यामभ्युक्तम् । अङ्गादङ्गात्स​म्भवसि...स जीव शरदः शतम् ।। 
+
+    अविशेषेण पुत्राणादायोभवति धर्मतः। मिथुनानां विसर्गादो मनुः स्वायम्भुवोब्रवीत् ।।. The first half of the verse 'Aṇgād-aṇgāt' occurs in. Bṛ. Up. VI. 4. 9 and in Kauṣitaki Up. 2. 11 (three pādas) and the whole verse in Baud. Gṛ. and Āśv Gṛ. and in mantra-pāṭha II. 11. 33. The Mānavagṛhyasūtra (I. 18. 1) provides that the verse 'aṇgād-aṇgāt,' quoted io n. 47, was to be muttered over the son's head after the father returned from a journey. It may be noted that in the extant Manusmṛti 'Manuḥ Svāyambhuvoऽbravīt' occurs in IX. 158 and the words 'Manurāha Prajāpatiḥ' occur in X. 78 and the words 'tan-Manoranu śāsanam' occur in VIII. 139 and 279 and in IX. 239. This shows that the śloka quoted by the Nirukta might have been contained in some Smṛti work like the extant Manusmṛti. Vide Manu IX. 133 and 139 for the underlying idea that there is no difference between the son's son and the daughter's son and therefore between son and daughter. 
+
+    As stated in Gautama, Manu, Yāj. and others, Śruti and Smṛti are the most authoritative sources of Dharma and Manusmṛti II. 10 states that Smṛti is Dharmaśāstra. This list in a broad sense comprises the Gṛhya and Dharmasūtras, metrical smṛtis like those of Manu, Yāj, Brhaspati, Parāśara, commentaries on them and digests (nibandhas).
+
+[^48]: गौ. ध​. सू. 8. 9.21 'तस्य च व्यवहारो वेदो धर्मशास्त्राण्यङ्गानि उपवेदाः पुराणम्'. The words पृथग्धर्मविदस्त्रयः in गौ. ध. सू. 28. 47 appear to refer to students of धर्मशास्त्र.
+
+[^49]: त्रीणि प्रथमान्यनिर्देश्यनि मनुः । गौ. ध. सू. 21. 7.
+
+[^50]: धर्मशास्त्रं च तथा । Vide महाभाष्य vol. I. p. 242.
+
+[^51]: शूद्रश्च धर्मशास्त्रत्वात् । पू. मी. सू. VI. 7. 6. 
+
+[^52]:
+    नैवेश्वर आज्ञापयति नापि धर्मसूत्रकाराः पठन्ति अपवादैरुत्सर्गा बाध्यन्तामिति ।
+
+    महाभाष्य vol. I, p. 115 and vol. II, p. 365. पतञ्जलि quotes आम्राश्च सिक्ताः पितरश्च प्रीणिताः (vol. I. p. 14.) for which vide आप. ध. सू. I. 7. 20. 3 'तद्यथाम्रे फलार्थे निमित्ते छाया गन्ध इत्यनूत्पद्येते.' पतञ्जलि says 'तैलं न विक्रेतव्यं मांसं न विक्रेतव्यम्' and लोमनखं स्पृष्ट्वा शौचं कर्तव्यम् (vol. I. p. 25). The words नैवेश्वर आज्ञापयति may also mean 'A king (ruler) does not command' &c. The Gaut. Dh. S. IX. 53 provides that a learned brāhmaṇa may approach a ruler for his own 'yogakṣema'. Similarly. the Mahābhāṣya itself (Vol. III. p. 7) on Vārtika 9 on Pāṇ. VI. 1. 2 has the words 'लोक ईश्वर आज्ञापयति प्रामाद् ग्रामान्मनुष्या आनीयन्ताम्' where 'Īśvara' can only mean 'king or ruler.' Pāṇini in I. 4. 97 (adhirīśvare) and in II. 3. 39 uses Īśvara in the sense of ruler or owner. There is not much to choose between the two senses. If 'Īśvara' is taken to mean 'God' the meaning would be 'God (i.e. Veda, the word of God) does not order &c.' Vide बृह​. उप​. II. 4.10 'अस्य महतो भूतस्य निःश्वसितमेतद्यद्य्ग्वेदो यजुर्वेदः सामवेदोऽथर्वाङ्गिरसः' on which the Vedāntasūtra शास्त्रयोनित्वात् (1.1.3) is based.
+
+[^52a]:
+    A few passages from the Mahābhāṣya having a striking identity or similarity to Dharmasūtra texts may be cited bere. (1) दूरादावसथान्मूत्रं दूरात्पादावसेचनम् । दूराच्च भाव्यं दस्युभ्यो दूराच्च कुपिताद्गुरोः ।। महाभाष्य (vol. I. p. 457) on वार्तिक​ 2 on पा. II. 3. 35: compare गौ. ध. सू. 9. 39, आप. ध. सू. I. 11. 31. 2. मनु IV. 151 (first half), अनुशासनपर्व​ 104.82: (2) या ब्राह्मणी सुरापी भवति नैनां देवाः पतिलोकं नयन्ति । महाभाष्य Vol. 11, p. 99 on वार्तिक​ 2 on पा. III 2. 8; compare वसिष्ठधर्मसूत्र​ 21.11; (3) ऊर्ध्वं प्राणा ह्युत्क्रामन्ति यूनः स्थविर आयति । प्रत्युत्थानाभिवादाभ्यां पुनस्तान् प्रतिपद्यते ।। महाभाष्य, vol. III. p. 58 on वार्तिक​ 5 op पा. VI. 1. 84, which is मनु II. 120 and 2 अनुशासन 120. 64-65 and उद्योग​ 38. 1 (37. 1 in some editions); (4) गर्भाष्टमे ब्राह्मण उपनेयः इति सकृदुपनीय कृतः शास्त्रार्थ इति कृत्वा पुनः प्रवृत्तिर्न भवति । तथा त्रिर्हृदयंगमाभिरद्भिरशब्दाभिरुपस्पृशेदिति सकृदुपस्पृश्य कृतः शास्त्रार्थ इति कृत्वा पुनः प्रवृत्तिर्न भवति । महाभाष्य Vol III. p. 537 on वार्तिक​ 4 on पा. VI. 1. 84; compare वसिष्ठधर्मसूत्र​ III. 31.
+
+    Volume and page references relate to Kielhorn's ed. of the महाभाष्य. Vide the author's paper in Prof. F. W. Thomas Presentation vol. pp. 128-131.
+
+[^53]: Vide S. B. E. vol. II, p. IX, but see Goldstücker s 'Pāṇini' (pp. 59, 60, 78) against Max Müller and Prof. D. R. Bhandarkar's Carmichael lectures for 1918, pp. 105-107.
+
+
+[^53a]: आप. गृ. I. 1. 19. (पवित्रयो: संस्कार आयामतः परीमाणं पोक्षणीसंस्कारः पात्रप्रोक्ष इति द॒र्श॒पूर्ण॒मा॒स॒स्तूष्णी॒म्).  This extends four matters from the Āp. Śr. (I. 11. 7., I., 11. 6. I. 11. 9 and I. 11. 10 respectively) to gṛhya rites.
+
+
+[^53b]: This mantrapāṭha was most probably compiled before the Gṛhyasūtra as it forms praśnas 25 and 26 of the Āpastambīyakalpa and as the Āp. Gṛhya forms only the 27th praśna.
+
+[^53c]:
+    The Ait. Br. (adbyāya 3, kbaṇda 5) states 'etadvai yajñasya samṛddham yad-rūpasamṛddham yat karma kriyamāṇam ṛg-abhivadatīti.' The Nirukta (I. 16) quotes this passage but the words 'yajur-vā' after 'ṛg'. are added in mss. and editions. Jaimini affirms that there is no difference in the meanings of words employed in the Veda and ordinary life (P. M. S. I 2.32 'aviśiṣṭastu vākyārthaḥ') and Śabara remarks on this that mantras are recited in sacrifices for the purpose of conveying the meaning of what is being done (arthapratyāyanārtham-eva yajñe mantroccāraṇam). In this connection, vide Prof. M. V. Apte's paper 'The Ṛgveda mantras in their ritual setting in the gṛhyasūtras' published in the Bulletin of the D. C. R. I. (Poona) Vol. I. pp 14-44 and 127-152 and also his paper in Prof. Kunhan Raja Presentation Vol. pp. 233-240 where he concludes that the word mantra in the gṛhyasūtras came to have an extended meaning so as to comprise all types of liturgical formulae, metrical or prose &c.; vide H, of Dh. Vol. V. pp. 1220-1223 about Vedic Mantras.
+
+[^53d]: Vide, for an incomplete ms. of Bhartṛyajña, Catalogue of S. Mss of the Asiatic Society of Bengal, Vol. II. No. 1023 and I. H. Q. Vol. XII pp. 494-503, where it is shown that Karka knew Bhartṛyajña.
+
+[^53e]:
+    आक्ष्वलायनकं सूत्रं बैजवापिकृतं तथा । द्राह्यायणीय लाटीय​-कात्यायनकृतानि च । तन्त्रवार्तिक​ on पू. मी. I. 3. 11, p. 229 (Ānan. ed.). 
+
+    It is possible that the reference here may be to the Śrauta or Gṛhyasūtra of Baijavāpi or to both, just as we bave a śrauta sūtra and a gṛhyasūtra of Āśvalāyana. 


### PR DESCRIPTION
# Changes done:
- Fixed typo in the second paragraph. Changed **extant from** to **extant form**.
- Changed the list of gṛhyasūtras after the sixth paragraph into Markdown list format.
- Fixed bullet point (2) after (4) on page 17 to (5)
- Fixed typo in footnote 47: **last** to **list**.
- Fixed typo in footnote 53b from **aud** to **and**.

@vvasuki Please check if these changes and fixes are valid.