### PR TITLE
mark chapter titles in kANe v4

### DIFF
--- a/kANe/v4.md
+++ b/kANe/v4.md
@@ -36,6 +36,10 @@ and Published by Dr. R. X Daodchar, Y.A.Pb D, Hon. Secretary,
 
 Bbandarlar Oriental Research Iostitate, Poona + 
 
+## 0
+
+### Table of Contents
+
 TABLE OR CONTENTS 
 
 Page 
@@ -57,6 +61,8 @@ Fri-rui
 828-833 835-922 923-920 
 
 ... 
+
+### Preface
 
 PREFACE 
 
@@ -96,7 +102,11 @@ BOMBAY, }
 
 PV KANE 
 
-$ I take this opportunity of correcling two mistahes that I regret I committed in the third solame of the History of Dharmasāstra. In note 1886 on p 968 (of vol III) I refer to a work of Mr Batul oath Bhattacharya that contaigs a full treatment of Kalivarjya, I suggested 10 tbat note that Mr, Bhattacharya probably retouched his thesis after 1937 though it was written in 1933, in view of the fact that he referred to the Smrtimuktāphala (which was published in 1937 by Mr Gbarpure) Through oversight I forgot that Mr. Bhattacharya had expressly stated that he used the transcript of a ms of the Sportimuktāphala specially made for him. Therefore, I was wrong in my surmise that he probably retouched his thesis and I must say that the thesis as publisbed in 1943 is the same as that written in 1933 for the Jogendrachandra Ghosc Research Prize The second mistake refers to Dr, U, N Ghosal on p 32 (of sol III) I stated 'it is not possible to hold as Jayaswal, U Ghosal and others do tbat the theory of social contract was the earlier one aod the theory of diviac right of kings sas later on propound ed by the Manusmrti to support tbe brābmana empire of Pusyamitra' IA Writing this sentence my memory was at fault I find that Dr. Ghosal does not hold the view that I attributed to bim. In the 'Indian Historical Quarterly' (vol 23, pp 68-70) Dr Ghosal justly protests against my bracketrag him with Jayasual, but I cannot help observing that the last sentence in the paper shows unexpecled accrbily In bis whole career as a writer Dr Ghosal was not probably guilty of a single slip and could not therefore briog bimself to belici e that may maustahe might bave beca bona fide.. .. ABBREVIATIONS 
+$ I take this opportunity of correcling two mistahes that I regret I committed in the third solame of the History of Dharmasāstra. In note 1886 on p 968 (of vol III) I refer to a work of Mr Batul oath Bhattacharya that contaigs a full treatment of Kalivarjya, I suggested 10 tbat note that Mr, Bhattacharya probably retouched his thesis after 1937 though it was written in 1933, in view of the fact that he referred to the Smrtimuktāphala (which was published in 1937 by Mr Gbarpure) Through oversight I forgot that Mr. Bhattacharya had expressly stated that he used the transcript of a ms of the Sportimuktāphala specially made for him. Therefore, I was wrong in my surmise that he probably retouched his thesis and I must say that the thesis as publisbed in 1943 is the same as that written in 1933 for the Jogendrachandra Ghosc Research Prize The second mistake refers to Dr, U, N Ghosal on p 32 (of sol III) I stated 'it is not possible to hold as Jayaswal, U Ghosal and others do tbat the theory of social contract was the earlier one aod the theory of diviac right of kings sas later on propound ed by the Manusmrti to support tbe brābmana empire of Pusyamitra' IA Writing this sentence my memory was at fault I find that Dr. Ghosal does not hold the view that I attributed to bim. In the 'Indian Historical Quarterly' (vol 23, pp 68-70) Dr Ghosal justly protests against my bracketrag him with Jayasual, but I cannot help observing that the last sentence in the paper shows unexpecled accrbily In bis whole career as a writer Dr Ghosal was not probably guilty of a single slip and could not therefore briog bimself to belici e that may maustahe might bave beca bona fide.. .. 
+
+### Abbreviations
+
+ABBREVIATIONS 
 
 (Most of the abbreviations on pp. 728-29 
 
@@ -344,6 +354,8 @@ History of Dharmaśāstra वाज सं. वाजसनेयसंहित
 
 स्मृतिमु or स्मृ मु.-स्मृतिमुक्ताफल गाड्वायनवा or गा वा =शाड्डायनत्राह्मण श्रा. वि =श्राद्धविवेक of रूधर गां. श्री. or गां श्री. सु.गाडायनश्रौतसूत्र हिर गृ. or हिरण्य गृ.-हिरण्यकेगिगृह्यसूत्र 
 
+### Chronological Table
+
 CHRONOLOGICAL TABLE 
 
 OF some important Sanskrit works and authors referred 
@@ -488,6 +500,8 @@ in sake 1712 1730-1820-Bālambhatta, author of a commentary on the Mitālsarā,
 
 called Bālambhatti 
 
+### Synopsis of Contents
+
 BRIEF SYNOPSIS 
 
 OF THE CONTENTS OF VOLUME IV 
@@ -595,6 +609,8 @@ Chapter XVI Comprehensive list of tīrthas and con
 cluding remarhs on tīrthas 
 
 ... 723-827 
+
+### Important Works Consulted
 
 IMPORTANT WORKS CONSULTED 
 
@@ -786,7 +802,11 @@ Dism and in the Vedas' Prof Keith's ' Religion and Philosopby of the Veda and Up
 
 of India by Alexander' and 'Ancient India as described by 
 
-Ptolemy. A. A Macdonell's 'Vedic Mythology' Sir John Marshall's 'Mohenjo-daro '(in three volumes ) Rajendralal Mitra's 'Buddha-Gayā' (1878) B. S Puckle's 'Funeral customs' Reginald Reynolds on 'cleanliness and godliness' Sacred Books of the East, edited by F. Max-Muller Tawney's translation of Prabandba-cintamani' C, E, Vullsamy's 'Immortal man'INDEX OF CASES CITED 
+Ptolemy. A. A Macdonell's 'Vedic Mythology' Sir John Marshall's 'Mohenjo-daro '(in three volumes ) Rajendralal Mitra's 'Buddha-Gayā' (1878) B. S Puckle's 'Funeral customs' Reginald Reynolds on 'cleanliness and godliness' Sacred Books of the East, edited by F. Max-Muller Tawney's translation of Prabandba-cintamani' C, E, Vullsamy's 'Immortal man'
+
+### Index of Cases Cited
+
+INDEX OF CASES CITED 
 
 Akshayacandra u Hajdas 511 Chandrachoora Das v Bibhutz Bhushan 218, 220 Darbarılal v Govindlal 569 Digambar v Motrial 510 Dinanath v Hrishikesh 569, 573n Dwarkanath Misser v Rampertab 581 Ganpat v Tulsiran 569 Gangaram Babajr Badve v Bagi Shankar 713n Gangaram. Babaji v Narayan Anajı 7140 Gooroo Gobinda Sala v Anandlal 510 Gopala Muppanar v Dhamakasta Subramania 318 Harı v Bajrand 569n Lachman Lal v Baldeo Lal 581 Lachan Lal v Kanhaya Lal 581 Maharani Hemanta Kumari v Gail ishankar 6330 Matteram v Gopal 569 Nalinaksha v Rajankanto 510 Narayan Lal v Chathan Lal 581 Narları v Bhimrao 323 Reg. v Price 233 Sardar S111811 v Kunj Behari S. K. Wodeyar v Ganapati 318 Sakharam Bhrinaji Benare v Gangasan Babajz 713n Saklat v Bella 
 
@@ -799,6 +819,8 @@ Akshayacandra u Hajdas 511 Chandrachoora Das v Bibhutz Bhushan 218, 220 Darbarı
 5810 13 C. L. J. 449, 581n 15 C. L. J. 376, 581n 22 I. A, 51, 5810 +1 1. A. 27n 2 Patna L. J. 5810 A. I. R. (1945 ) Patna 211, 220 2 Patna Law Journal 581n 
 
 H, D, 17 
+
+### Additions and Corrections
 
 ADDITIONS AND CORRECTIONS 
 
@@ -1014,11 +1036,15 @@ p 110 quotes a verse of Devala enumerating seven nadas energia sia që i RICET 7
 
 Lohita is Brahmaputrā 832 line 5 Read 'Bitrat 832 lines 8 and 10 Read it and a 832 line 18 Read ai 832 n. 693a 1 3 Read FAIT 
 
+## 1 Pātaka, Prāyaścitta, Karmavipāka
+
 SECTION I 
 
 PĀTAKA, PRĀYAŚCITTA AND KARMAVIPAKA 
 
 (Sins, expiations and the residual consequences of sins). 
+
+### 01 Pātaka
 
 CHAPTER I 
 
@@ -1652,6 +1678,8 @@ Before proceeding with the subject of prāyaścittas we shall speak briefly abou
 
 97 पत्नी वाचति मेध्यामेवैनां करोति । अथो तप एवैनामुपनयति । यजार . याहयति । NAFTE EITHE STA GEagai ā ET I 6,5, vide note 91 above for be paggage yo ...ETETT 
 
+### 02 Means of Reducing Consequences of Sins
+
 CHAPTER II 
 
 MEANS OF REDUCING CONSEQUENCES OF SINS 
@@ -1921,6 +1949,8 @@ caste and hold them pure if a Government order was issued Then the Peshwa issued
 136. Vide Trā 
 
 aus Gletter 113 p 225 
+
+### 03 Prayaścitta
 
 CHAPTER III PRAYAŚCITTA; ITS ORIGIN, DERITATION 
 
@@ -2419,6 +2449,8 @@ If the learned brahmanas of the assembly knowing the proper prāyaścitta do not
 205 विचारस्वाहशकायों यथा सर्वे सभासद । एकवाक्यतया ब्युरतथा अयोधित गच्छति ॥ by माय सा p 18 
 
 206. आतांना मार्गमाणानां प्रायश्चित्तानि ये द्विजा । जानन्तो न प्ररच्छन्ति ते यागा समतां तु तै. द्धिास. by मिता on या III 300, माय, तत, P.512. परा. मा II part 1p 234. 
+
+### 04 Penances for Particular Sins
 
 CHAPTER IV 
 
@@ -3108,6 +3140,8 @@ Some interesting sidelights ara thrown on the prices of milch cows, cows and bul
 
 1. D. 17 
 
+### 05 Names of All Prāyaścittas
+
 CHAPTER V NAMES OF ALL PRĀYAŚCITTAS 
 
 Now all the prāyaścittas mentioned in the smrtis and digests will be arranged in alphabetical order (Sanskrit, transliterated into English), excepting mere hymns, fasts, &c. and brief explanations and references will be added to each. 
@@ -3570,7 +3604,11 @@ SAUMYAKRCCRA-According to Yāj II. 321 this penance lasts for six days, in the f
 
 types of ASTOT I Uhera @ 778 W ATCER I ST. 972897 
 
-Hintality folio 460CHAPTER VI - 
+Hintality folio 460
+
+### 06 Consequences of Not Undergoing Penances
+
+CHAPTER VI - 
 
 CONSEQUENCES OF NOT UNDERGOING PENANCES 
 
@@ -3986,9 +4024,13 @@ M
 
 a gasin TETT TETTUATE TE सिठेति रक्तपुष्पाक्षते स्थापयेत् । ओ भूर्भुव स्त्र , अवन्तीसमुद्भव भरद्वाजसगोत्र भौम इवागच्छे. For furtha Aruari 314\#T= gu TEMES... I PETUA, follo 157 b, 
 
+## 2 Antyeṣṭi, Āśauca, Śuddhi
+
 SECTION II 
 
 ANTYESTI (rites after death ), SUDDHI ( purification from impurity due to death, birth and other causos) 
+
+### 07 Eschatology
 
 CHAPTER VII 
 
@@ -5354,6 +5396,8 @@ yātāniya' or 'ativāhika' and asserts that this body is made up of the element
 
 595. यस्यैतानि न दीयन्ते भेतश्राद्धानि पोडश । पिशाचवं भ्रवं तस्य दत्तै भाद्र शतैरपि। यम. by मा कि. को p. 362 and तखार्थकौमुदी on प्रा.वि p. 14. Almost the same verse is for hamara V. 16 and The Tro, Haus 34. 131, 
 
+### 08 Śuddhi
+
 CHAPTER VIII 
 
 SUDDHI 
@@ -6534,7 +6578,11 @@ Reason of emphasis on purification
 
 (as stated in the Chandogyopanisad VII, 26,2 fahārasuddhau sattvasuddbih' and by Harita). It would be conceded that some of their rules about purification (such as about large quantities of corn or heaps of cooked food) are based on common sense and convenience. We are probably going to the other extreme in taking our food anywhere and in any surroundings. 
 
+## 3 Śrāddha
+
 SECTION III 
+
+### 09 Introduction
 
 CHAPTER IX 
 
@@ -9482,6 +9530,8 @@ If even uncooked food grains cannot be offered the per forner should perform hem
 
 1149 a FAP a garen gainee HET: 1 vrkoj te gaan FIT N Erica and praraq g. in Burg p. 468, grāta. folio 1242. 
 
+### 10 Ekoddiṣta and Other Śrāddhas
+
 CHAPTER X 
 
 EKODDISTA AND OTHER SRADDHAS 
@@ -10086,7 +10136,13 @@ implemented by actual practice, it will make the whole world kin. Therefore, whi
 
 * In passing I may mention that my friend Mr. N, G. Chapekar, B.A, LL B, retired First Class Subordinate Judge residing at Badlapur in the Thana District, has been celebrating the yearly sraddba of his mother 10 the manner ladicated abos e for about twenty-five years, 
 
-SECTION IV CHAPTER XI 
+## 4 Tīrthayātrā
+
+SECTION IV 
+
+### 11 Introduction
+
+CHAPTER XI 
 
 TIRTHAYĀTRĀ (pilgrimages to holy places) 
 
@@ -10613,6 +10669,8 @@ History of Dharmaśāstra
 [Vol. in his own house (in the case of other tirthas) and then start. Then the next day he should bathe with pure clothes on and then put on his pilgrim dress and start on his pilgrim age in the forenoon with his face to the east, preferably bare-footed. There are two views here. Some say that on the day on which a man reaches a tirtha he should observe a fast, while the other view is that the pilgrim should fast on the day previous to his reaching the tirtha. In the first case he will have to perform a śrāddha on the day of the fast and in that case he cannot actually taste the remnants of śrāddha food but should only smell the cooked food The Kalpataru (on tirtha p 11) and the Tīrtha-cintāmani (p 14) quote Davala for the proposition that a fast on reaching a tirtha is not obligatory, but if observed yields special merit, 
 
 a man reaches views here. Some east, preferably 
+
+### 12 The Ganges
 
 CHAPTER XII 
 
@@ -11188,6 +11246,8 @@ HFA UE I 38 1; FEET 107.7 is very nearly the same
 
 H. D. 78 
 
+### 13 Kāśī
+
 CHAPTER XIII 
 
 KAŚĪ 
@@ -11614,7 +11674,11 @@ II, D, 81
 
 I Vol 
 
-"high schools of Hindu Sciences,' to Ain, A. vol. II, p. 158 'from time immemorial it has been the chief seat of learning in Hindustan' and to Kāśikhanda, chap. 96. 121 that states that Kāśi is the home of learning (vidyānām sadanam Kasi). Vide Prof. Altekar's 'History of Benares* pp. 23-24 and I A Yol. 41 pp. 7-13 and 245-253 for some learned families of BanarasCHAPTER XIV 
+"high schools of Hindu Sciences,' to Ain, A. vol. II, p. 158 'from time immemorial it has been the chief seat of learning in Hindustan' and to Kāśikhanda, chap. 96. 121 that states that Kāśi is the home of learning (vidyānām sadanam Kasi). Vide Prof. Altekar's 'History of Benares* pp. 23-24 and I A Yol. 41 pp. 7-13 and 245-253 for some learned families of Banaras
+
+### 14 Gayā
+
+CHAPTER XIV 
 
 GAYA 
 
@@ -12191,6 +12255,8 @@ Srāddhas at subtirihas
 ty miles from Deyagiri or Daulatabad). The Sivapurāna (Kotidrudra-samhita) chap. 1 names the twelve Jyotirlingas and chapters 14-33 narrate the legends connected with the twelve lingas, The SkandapuranaI (Kedarakhanda) chap. 7 Verses 30-35 enumerate several lingas including most of the twelve Jyotirlingas. The Bārhaspatyasūtra (edited by Dr. F. W. Thomas ) mentions eight great tirthas each of Visnu, Siya and Sakti, that yield all sıddhis 1537a. 
 
 1537 3. अष्ट वैष्णवक्षेत्राः। बदरिका-सालग्राम-पुरुषोत्तम-द्वारका-बिल्वाचल-अनन्त सिंह-श्रीरङ्गाः। अटौ शैवाः। आविमुक्त गङ्गाद्वार-शिवक्षेत्र रामेयमुना (!)-शिवसरस्वती-मन्य शार्दूल गजक्षेत्राः । शाक्ता अष्टौ च ओग्योण-जाल-पूर्ण काम-फ्रोल-श्रीशैल-काञ्ची-महेन्द्राः। एते महाक्षेत्रा. सर्वसिद्धिकराव। बाईस्पत्यसूत्र III 119-126. 
+
+### 15 Kurukṣetra and Other Famous Tīrthas
 
 CHAPTER XV 
 
@@ -12965,6 +13031,8 @@ The question of the attitude that modern Hindus should adopt towards holy places
 
 
 CHA PIND rete 
+
+### 16 List of Tīrthas
 
 CHAPTER XVI - - LIST OF TĪRTHÁS 
 
@@ -20182,6 +20250,10 @@ of one part of Bhārata are bound up with the destinies of all others. Frequent 
 
 Ś While these pages were passing tbrough the Press, news was broad fast on the scry morning of the coronation of Queen Elizabeth II tbat Sherpa Tensing Norkay and Mr Edmond Hillary, tiro pembers of Col. Huot's Brilish Expedition, had successfully climbed to the top of Mount Everest, 
 
+## 5
+
+### Appendix of Long Sanskrit Passages
+
 828 
 
 History of Dharmasāstra 
@@ -20271,6 +20343,8 @@ endar
 हीने स्वं लघु वा तदीयमधिक शूदे. समा. सङ्खराः॥ १० The text of the r egait bere priated is based on three mss, from the Deccan College collection (now at the Bhandarkar Oriental Tostitute, Poona), viz. No. 216 of 1879-80 copied in samvat 1539 (1482A D.), No. 196 of 1884-1887 copied in samvat 1578 (1521 A D.) and No 85 of 1895–1902 copied in savivat 1780. All these mass, contain the blijsya af Hanhara, which ascribes the work to Fastraat in the first as the commentary on the first three verses is wanting. I intended at first to give explanations in Sanskrit of these verses (as p 308 will indicate) but owing to considerations of space I omitted the Sanskrit explanations. 
 
 H. D 105 
+
+### General Index
 
 GENERAL INDEX 
 
@@ -24524,7 +24598,11 @@ regards burial of a human body in
 
 the earth as a grave sia 2310 Zoroastrians, disposed of the dead by 
 
-exposure of dead bodies to sultores and other birds 2310INDEX OF DIPORTANT WORDS 
+exposure of dead bodies to sultores and other birds 2310
+
+### Index of Important Words
+
+INDEX OF DIPORTANT WORDS 
 
 Abbicara 35 Abhidroha 5 Abbiśasta 13 Abbivāngā 4260 Abhyadayılaśrāddba 3598 Acārya, 2810 Adhāna 5740 Adya ( $rāddba) 5180 Āgas 5-6 Agha (sin) 6 Agha (asauca ) 267-268 Agnisvātta 195a, 343 Agradidbisu 11 Agredidhıṣu 11n, 3940 Agrabayani 354 Abava 5030 Akalkaka 5620 Alrtidabana 225 Aksayyodala 5080 Amantrana 408 Amatya 1990 Amhas 6 Ambati 7 Anadya 4020 Anasaka 42 Anavasthi Gla Anrta 5,7 Adogrābaka 17 Anukalpa 387,513 Anopātaha 15 Anustarani 206 Apzölteya 391 Aparābna 376 Aposana 4960 Aprita 3150 Aratoi 4700 Argbya 419, 435a Aranyapi 5610 
 


### PR DESCRIPTION
Notes: 

1. The following chapters did not have titles in the text. I have given titles for them based on their content.

    > 01 Pātaka
    > 09 Introduction
    > 11 Introduction

2. This volume, like v3, contains sections/subdivisions. And these sections, unlike v3, also have titles.