### PR TITLE
Update 12_the_dharmasUtra_of_sankha-likhita.md

### DIFF
--- a/dharmaH/nibandhaH/en/kANe/history/v1p1/12_the_dharmasUtra_of_sankha-likhita.md
+++ b/dharmaH/nibandhaH/en/kANe/history/v1p1/12_the_dharmasUtra_of_sankha-likhita.md
@@ -6,7 +6,7 @@ short_title = "12 The Dharmasūtra of"
 12 The Dharmasūtra of Saṅkha-Likhita
 
 From the Tantravārtika we learn (note 55 above) that the Dharmasūtra of Śaṅkha-Likhita was specially studied by the Vājasaneyins (the followers of the white Yajurveda ). The Tantravārtika also quotes a few words from that Dharmaśūtra which constitute an Anuṣṭubh pāda[^132]. The Mahābhārata (in Śāntiparvan, chap. 23. 18-43 ) narrates the story of the two brothers, Śaṅkha and Likhita, who resided in separate dwellings surrounded by trees. Once Likhita came to the āśrama (hermitage ) of Śaṅkha in his absence. He took some ripe fruits from some of the trees of Śaṅkha’s āśrama and ate them. While he was eating, Śaṅkha came and asked him where he got the fruits. Likhita smiled and told his brother that he took them from his trees. Then Śaṅkha got angry and told his brother that he was guilty of theft and asked
-[^132]:तन्त्रवार्तिक, p. 139 ‘स्मार्वधर्माधिकारे हि   शङ्खलिखिताभ्यामुक्तम्- आश्रयः स्मृतिधारकः’. 
+[^132]:तन्त्रवार्तिक, p. 139 ‘स्मार्तधर्माधिकारे हि शङ्खलिखिताभ्यामुक्तम्- आश्रयः स्मृतिधारकः’. 
 
 131 taon na H21 JmT: I ho fa cremat ro f 3: 1 
 


### PR DESCRIPTION
131. [[हारीतेनापि केचन भेदा उक्ताः । एकमूलो द्विरूपानो द्विस्कन्धो द्विफलः । कात्यायनस्तु तान् व्याचष्टे । 2nd Ullasa, p. 61 (Mysore edition ).|हारीतेनापि केचन भेदा उक्ताः । एकमूलो द्विरूपानो द्विस्कन्धो द्विफलः । कात्यायनस्तु तान् व्याचष्टे । 2nd Ullasa, p. 61 (Mysore edition ).]]
132. [[तन्त्रवार्तिक, p. 139 ‘सार्वधर्मिकारे हि शङ्खलिखितयाम् तु कम्-- आश्रयः स्मृतिधारकः’.|तन्त्रवार्तिक, p. 139 ‘सार्वधर्मिकारे हि शङ्खलिखितयाम् तु कम्-- आश्रयः स्मृतिधारकः’.]]

<img width="1572" height="991" alt="image" src="https://github.com/user-attachments/assets/8875a0f6-0a7e-48cf-8a5a-0491f4503764" />


AI prompted above footnote. Should that be added too?